### PR TITLE
Make admin key index configurable for creating proposal keys

### DIFF
--- a/accounts/config.go
+++ b/accounts/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	AdminAccountAddress   string       `env:"ADMIN_ADDRESS,notEmpty"`
 	ChainID               flow.ChainID `env:"CHAIN_ID" envDefault:"flow-emulator"`
 	AdminProposalKeyCount uint16       `env:"ADMIN_PROPOSAL_KEY_COUNT" envDefault:"1"`
+	AdminAccountKeyIndex  int          `env:"ADMIN_KEY_INDEX" envDefault:"0"`
 }
 
 // ParseConfig parses environment variables to a valid Config.

--- a/accounts/service.go
+++ b/accounts/service.go
@@ -84,6 +84,7 @@ func (s *Service) addAdminProposalKeys(ctx context.Context, count uint16, txServ
 	_, _, err := txService.Create(ctx, true, s.cfg.AdminAccountAddress, templates.Raw{
 		Code: template_strings.AddProposalKeyTransaction,
 		Arguments: []templates.Argument{
+			cadence.NewInt(s.cfg.AdminAccountKeyIndex),
 			cadence.NewUInt16(count),
 		},
 	}, transactions.General)

--- a/templates/template_strings/transactions.go
+++ b/templates/template_strings/transactions.go
@@ -75,9 +75,9 @@ transaction {
 `
 
 const AddProposalKeyTransaction = `
-transaction(numProposalKeys: UInt16) {  
+transaction(adminKeyIndex: Int, numProposalKeys: UInt16) {  
   prepare(account: AuthAccount) {
-    let key = account.keys.get(keyIndex: 0)!
+    let key = account.keys.get(keyIndex: adminKeyIndex)!
     var count: UInt16 = 0
     while count < numProposalKeys {
       account.keys.add(


### PR DESCRIPTION
The script that adds weightless proposal keys assumes the admin key is at index 0. This assumption is sometimes wrong and we should refer to the `ADMIN_KEY_INDEX` environment variable to know which index holds the admin key.