### PR TITLE
Admin as payer on all outgoing transactions

### DIFF
--- a/api/scripts.http
+++ b/api/scripts.http
@@ -23,7 +23,7 @@ content-type: application/json
 
 {
   "code":"import FungibleToken from 0xee82856bf20e2aa6\nimport FlowToken from 0x0ae53cb6e3f42a79\npub fun main(account: Address): UFix64 {\nlet vaultRef = getAccount(account)\n.getCapability(/public/flowTokenBalance)\n.borrow<&FlowToken.Vault{FungibleToken.Balance}>()\n?? panic(\"Could not borrow Balance reference to the Vault\")\nreturn vaultRef.balance\n}",
-  "arguments":[{"type":"Address","value":"{{$dotenv ADMIN_ADDRESS}}"}]
+  "arguments":[{"type":"Address","value":"{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}"}]
 }
 
 ### Get ExampleNFT balance of admin account (flow-emulator)
@@ -31,6 +31,6 @@ POST http://localhost:3000/v1/scripts HTTP/1.1
 content-type: application/json
 
 {
-  "code":"import NonFungibleToken from {{$dotenv ADMIN_ADDRESS}}\nimport ExampleNFT from {{$dotenv ADMIN_ADDRESS}}\n\npub fun main(account: Address): [UInt64] {\n    let receiver = getAccount(account)\n        .getCapability(ExampleNFT.CollectionPublicPath)!\n        .borrow<&{NonFungibleToken.CollectionPublic}>()\n        ?? panic(\"failed to borrow reference to collection\")\n    return receiver.getIDs()\n}\n",
-  "arguments":[{"type":"Address","value":"{{$dotenv ADMIN_ADDRESS}}"}]
+  "code":"import NonFungibleToken from {{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}\nimport ExampleNFT from {{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}\n\npub fun main(account: Address): [UInt64] {\n    let receiver = getAccount(account)\n        .getCapability(ExampleNFT.CollectionPublicPath)!\n        .borrow<&{NonFungibleToken.CollectionPublic}>()\n        ?? panic(\"failed to borrow reference to collection\")\n    return receiver.getIDs()\n}\n",
+  "arguments":[{"type":"Address","value":"{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}"}]
 }

--- a/api/tokens.http
+++ b/api/tokens.http
@@ -15,7 +15,7 @@ content-type: application/json
 
 {
   "name":"ExampleNFT",
-  "address":"{{$dotenv ADMIN_ADDRESS}}",
+  "address":"{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}",
   "type":"NFT",
   "setup":"import NonFungibleToken from \"../contracts/NonFungibleToken.cdc\"\nimport ExampleNFT from \"../contracts/ExampleNFT.cdc\"\ntransaction {\n    prepare(signer: AuthAccount) {\n        if signer.borrow<&ExampleNFT.Collection>(from: ExampleNFT.CollectionStoragePath) != nil { return }\n        let collection <- ExampleNFT.createEmptyCollection()\n        signer.save(<-collection, to: ExampleNFT.CollectionStoragePath)\n        signer.link<&NonFungibleToken.Collection>(ExampleNFT.CollectionPublicPath, target: ExampleNFT.CollectionStoragePath)\n    }\n}\n",
   "transfer":"import NonFungibleToken from \"../contracts/NonFungibleToken.cdc\"\nimport ExampleNFT from \"../contracts/ExampleNFT.cdc\"\ntransaction(recipient: Address, withdrawID: UInt64) {\n    prepare(signer: AuthAccount) {\n        let recipient = getAccount(recipient)\n        let collectionRef = signer.borrow<&ExampleNFT.Collection>(from: ExampleNFT.CollectionStoragePath)!\n        let depositRef = recipient.getCapability(ExampleNFT.CollectionPublicPath)!.borrow<&{NonFungibleToken.CollectionPublic}>()!\n        let nft <- collectionRef.withdraw(withdrawID: withdrawID)\n        depositRef.deposit(token: <-nft)\n    }\n}\n",
@@ -43,27 +43,27 @@ content-type: application/json
 
 
 ### Get accounts fungible tokens for admin account
-GET http://localhost:3000/v1/accounts/{{$dotenv ADMIN_ADDRESS}}/fungible-tokens HTTP/1.1
+GET http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/fungible-tokens HTTP/1.1
 content-type: application/json
 
 ### Get accounts non-fungible tokens for admin account
-GET http://localhost:3000/v1/accounts/{{$dotenv ADMIN_ADDRESS}}/non-fungible-tokens HTTP/1.1
+GET http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/non-fungible-tokens HTTP/1.1
 content-type: application/json
 
 ### Get FlowToken details for admin account
-GET http://localhost:3000/v1/accounts/{{$dotenv ADMIN_ADDRESS}}/fungible-tokens/FlowToken HTTP/1.1
+GET http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/fungible-tokens/FlowToken HTTP/1.1
 content-type: application/json
 
 ### Get FUSD details for admin account
-GET http://localhost:3000/v1/accounts/{{$dotenv ADMIN_ADDRESS}}/fungible-tokens/FUSD HTTP/1.1
+GET http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/fungible-tokens/FUSD HTTP/1.1
 content-type: application/json
 
 ### Get ExampleNFT details for admin account
-GET http://localhost:3000/v1/accounts/{{$dotenv ADMIN_ADDRESS}}/non-fungible-tokens/ExampleNFT HTTP/1.1
+GET http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/non-fungible-tokens/ExampleNFT HTTP/1.1
 content-type: application/json
 
 ### Create a FlowToken withdrawal from admin to custody account
-POST http://localhost:3000/v1/accounts/{{$dotenv ADMIN_ADDRESS}}/fungible-tokens/FlowToken/withdrawals HTTP/1.1
+POST http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/fungible-tokens/FlowToken/withdrawals HTTP/1.1
 content-type: application/json
 
 {
@@ -72,7 +72,7 @@ content-type: application/json
 }
 
 ### Create a FUSD withdrawal from admin to custody account
-POST http://localhost:3000/v1/accounts/{{$dotenv ADMIN_ADDRESS}}/fungible-tokens/FUSD/withdrawals HTTP/1.1
+POST http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/fungible-tokens/FUSD/withdrawals HTTP/1.1
 content-type: application/json
 
 {
@@ -81,7 +81,7 @@ content-type: application/json
 }
 
 ### Create an ExampleNFT withdrawal from admin to custody account
-POST http://localhost:3000/v1/accounts/{{$dotenv ADMIN_ADDRESS}}/non-fungible-tokens/ExampleNFT/withdrawals HTTP/1.1
+POST http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/non-fungible-tokens/ExampleNFT/withdrawals HTTP/1.1
 content-type: application/json
 
 {
@@ -90,35 +90,35 @@ content-type: application/json
 }
 
 ### List FlowToken withdrawals for admin account
-GET http://localhost:3000/v1/accounts/{{$dotenv ADMIN_ADDRESS}}/fungible-tokens/FlowToken/withdrawals HTTP/1.1
+GET http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/fungible-tokens/FlowToken/withdrawals HTTP/1.1
 content-type: application/json
 
 ### List FUSD withdrawals for admin account
-GET http://localhost:3000/v1/accounts/{{$dotenv ADMIN_ADDRESS}}/fungible-tokens/FUSD/withdrawals HTTP/1.1
+GET http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/fungible-tokens/FUSD/withdrawals HTTP/1.1
 content-type: application/json
 
 ### List ExampleNFT withdrawals for admin account
-GET http://localhost:3000/v1/accounts/{{$dotenv ADMIN_ADDRESS}}/non-fungible-tokens/ExampleNFT/withdrawals HTTP/1.1
+GET http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/non-fungible-tokens/ExampleNFT/withdrawals HTTP/1.1
 content-type: application/json
 
 ### Get FlowToken withdrawal details for admin account
-GET http://localhost:3000/v1/accounts/{{$dotenv ADMIN_ADDRESS}}/fungible-tokens/FlowToken/withdrawals/<transaction_id> HTTP/1.1
+GET http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/fungible-tokens/FlowToken/withdrawals/<transaction_id> HTTP/1.1
 content-type: application/json
 
 ### Get ExampleNFT withdrawal details for admin account
-GET http://localhost:3000/v1/accounts/{{$dotenv ADMIN_ADDRESS}}/non-fungible-tokens/ExampleNFT/withdrawals/<transaction_id> HTTP/1.1
+GET http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/non-fungible-tokens/ExampleNFT/withdrawals/<transaction_id> HTTP/1.1
 content-type: application/json
 
 ### Setup FlowToken on emulator for admin account
-POST http://localhost:3000/v1/accounts/{{$dotenv ADMIN_ADDRESS}}/fungible-tokens/FlowToken HTTP/1.1
+POST http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/fungible-tokens/FlowToken HTTP/1.1
 content-type: application/json
 
 ### Setup FUSD on emulator for admin account
-POST http://localhost:3000/v1/accounts/{{$dotenv ADMIN_ADDRESS}}/fungible-tokens/FUSD HTTP/1.1
+POST http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/fungible-tokens/FUSD HTTP/1.1
 content-type: application/json
 
 ### Setup ExampleNFT on emulator for admin account
-POST http://localhost:3000/v1/accounts/{{$dotenv ADMIN_ADDRESS}}/non-fungible-tokens/ExampleNFT HTTP/1.1
+POST http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/non-fungible-tokens/ExampleNFT HTTP/1.1
 content-type: application/json
 
 
@@ -148,7 +148,7 @@ POST http://localhost:3000/v1/accounts/{{emulatorCustodyAccount}}/fungible-token
 content-type: application/json
 
 {
-  "recipient":"{{$dotenv ADMIN_ADDRESS}}",
+  "recipient":"{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}",
   "amount":"1.0"
 }
 
@@ -157,7 +157,7 @@ POST http://localhost:3000/v1/accounts/{{emulatorCustodyAccount}}/fungible-token
 content-type: application/json
 
 {
-  "recipient":"{{$dotenv ADMIN_ADDRESS}}",
+  "recipient":"{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}",
   "amount":"1.0"
 }
 

--- a/api/transaction.http
+++ b/api/transaction.http
@@ -9,7 +9,7 @@ content-type: application/json
 
 
 ### Get admin account transactions
-GET http://localhost:3000/v1/accounts/{{$dotenv ADMIN_ADDRESS}}/transactions?limit=0&offset=0 HTTP/1.1
+GET http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/transactions?limit=0&offset=0 HTTP/1.1
 content-type: application/json
 
 
@@ -17,7 +17,7 @@ content-type: application/json
 # TESTNET (ensure .env is set accordingly - ACCESS_API_HOST etc)
 
 ### Transfer FLOW on testnet, admin -> custody account
-POST http://localhost:3000/v1/accounts/{{$dotenv ADMIN_ADDRESS}}/transactions HTTP/1.1
+POST http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/transactions HTTP/1.1
 content-type: application/json
 
 {
@@ -32,7 +32,7 @@ content-type: application/json
 
 {
   "code":"import FungibleToken from 0x9a0766d93b6608b7\nimport FlowToken from 0x7e60df042a9c0868\ntransaction(amount: UFix64, recipient: Address) {\nlet sentVault: @FungibleToken.Vault\n  prepare(signer: AuthAccount) {\n    let vaultRef = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n      ?? panic(\"failed to borrow reference to sender vault\")\n\n    self.sentVault <- vaultRef.withdraw(amount: amount)\n  }\n\n  execute {\n    let receiverRef =  getAccount(recipient)\n      .getCapability(/public/flowTokenReceiver)\n      .borrow<&{FungibleToken.Receiver}>()\n        ?? panic(\"failed to borrow reference to recipient vault\")\n\n    receiverRef.deposit(from: <-self.sentVault)\n  }\n}",
-  "arguments":[{"type":"UFix64","value":"{{transferAmount}}"},{"type":"Address","value":"{{$dotenv ADMIN_ADDRESS}}"}]
+  "arguments":[{"type":"UFix64","value":"{{transferAmount}}"},{"type":"Address","value":"{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}"}]
 }
 
 
@@ -40,7 +40,7 @@ content-type: application/json
 # EMULATOR (ensure .env is set accordingly - ACCESS_API_HOST etc)
 
 ### Transfer FLOW on emulator, admin -> custody account
-POST http://localhost:3000/v1/accounts/{{$dotenv ADMIN_ADDRESS}}/transactions HTTP/1.1
+POST http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/transactions HTTP/1.1
 content-type: application/json
 
 {
@@ -54,12 +54,12 @@ content-type: application/json
 
 {
   "code":"import FungibleToken from 0xee82856bf20e2aa6\nimport FlowToken from 0x0ae53cb6e3f42a79\ntransaction(amount: UFix64, recipient: Address) {\nlet sentVault: @FungibleToken.Vault\n  prepare(signer: AuthAccount) {\n    let vaultRef = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n      ?? panic(\"failed to borrow reference to sender vault\")\n\n    self.sentVault <- vaultRef.withdraw(amount: amount)\n  }\n\n  execute {\n    let receiverRef =  getAccount(recipient)\n      .getCapability(/public/flowTokenReceiver)\n      .borrow<&{FungibleToken.Receiver}>()\n        ?? panic(\"failed to borrow reference to recipient vault\")\n\n    receiverRef.deposit(from: <-self.sentVault)\n  }\n}",
-  "arguments":[{"type":"UFix64","value":"{{transferAmount}}"},{"type":"Address","value":"{{$dotenv ADMIN_ADDRESS}}"}]
+  "arguments":[{"type":"UFix64","value":"{{transferAmount}}"},{"type":"Address","value":"{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}"}]
 }
 
 
 ### Run "Hello world" transaction on emulator
-POST http://localhost:3000/v1/accounts/{{$dotenv ADMIN_ADDRESS}}/transactions HTTP/1.1
+POST http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/transactions HTTP/1.1
 content-type: application/json
 
 {
@@ -68,10 +68,10 @@ content-type: application/json
 }
 
 ### Mint ExampleNFT for admin account
-POST http://localhost:3000/v1/accounts/{{$dotenv ADMIN_ADDRESS}}/transactions HTTP/1.1
+POST http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/transactions HTTP/1.1
 content-type: application/json
 
 {
-  "code":"import NonFungibleToken from {{$dotenv ADMIN_ADDRESS}}\nimport ExampleNFT from {{$dotenv ADMIN_ADDRESS}}\ntransaction(recipient: Address) {\n    let minter: &ExampleNFT.NFTMinter\n    prepare(signer: AuthAccount) {\n        self.minter = signer\n            .borrow<&ExampleNFT.NFTMinter>(from: ExampleNFT.MinterStoragePath)\n            ?? panic(\"Could not borrow a reference to the NFT minter\")\n    }\n    execute {\n        let recipient = getAccount(recipient)\n        let receiver = recipient\n            .getCapability(ExampleNFT.CollectionPublicPath)!\n            .borrow<&{NonFungibleToken.CollectionPublic}>()\n            ?? panic(\"Could not get receiver reference to the NFT Collection\")\n        self.minter.mintNFT(recipient: receiver)\n    }\n}\n",
-  "arguments":[{"type":"Address","value":"{{$dotenv ADMIN_ADDRESS}}"}]
+  "code":"import NonFungibleToken from {{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}\nimport ExampleNFT from {{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}\ntransaction(recipient: Address) {\n    let minter: &ExampleNFT.NFTMinter\n    prepare(signer: AuthAccount) {\n        self.minter = signer\n            .borrow<&ExampleNFT.NFTMinter>(from: ExampleNFT.MinterStoragePath)\n            ?? panic(\"Could not borrow a reference to the NFT minter\")\n    }\n    execute {\n        let recipient = getAccount(recipient)\n        let receiver = recipient\n            .getCapability(ExampleNFT.CollectionPublicPath)!\n            .borrow<&{NonFungibleToken.CollectionPublic}>()\n            ?? panic(\"Could not get receiver reference to the NFT Collection\")\n        self.minter.mintNFT(recipient: receiver)\n    }\n}\n",
+  "arguments":[{"type":"Address","value":"{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}"}]
 }

--- a/main.go
+++ b/main.go
@@ -243,14 +243,15 @@ func runServer(cfg *configs.Config) {
 				panic(err)
 			}
 
-			types := make([]string, len(*tt))
+			token_count := len(*tt)
+			event_types := make([]string, token_count)
 
 			// Listen for enabled tokens deposit events
 			for i, token := range *tt {
-				types[i] = templates.DepositEventTypeFromToken(token)
+				event_types[i] = templates.DepositEventTypeFromToken(token)
 			}
 
-			return types
+			return event_types
 		}
 
 		listener := chain_events.NewListener(fc, store, maxDiff, interval, getTypes)

--- a/tokens/chain_events.go
+++ b/tokens/chain_events.go
@@ -18,7 +18,8 @@ type ChainEventHandler struct {
 }
 
 func (h *ChainEventHandler) Handle(event flow.Event) {
-	if strings.Contains(event.Type, "Deposit") {
+	isDeposit := strings.Contains(event.Type, "Deposit")
+	if isDeposit {
 		h.handleDeposit(event)
 	}
 }
@@ -34,7 +35,7 @@ func (h *ChainEventHandler) handleDeposit(event flow.Event) {
 	amountOrNftID := event.Value.Fields[0]
 	accountAddress := event.Value.Fields[1]
 
-	// Check if recipient is in database
+	// Get the target account from database
 	account, err := h.AccountService.Details(accountAddress.String())
 	if err != nil {
 		return

--- a/tokens/chain_events.go
+++ b/tokens/chain_events.go
@@ -41,7 +41,7 @@ func (h *ChainEventHandler) handleDeposit(event flow.Event) {
 		return
 	}
 
-	if err = h.TokenService.RegisterDeposit(token, event.TransactionID.Hex(), amountOrNftID.String(), account.Address); err != nil {
+	if err = h.TokenService.RegisterDeposit(token, event.TransactionID, account, amountOrNftID.String()); err != nil {
 		fmt.Printf("Error while registering a deposit: %s\n", err)
 		return
 	}

--- a/tokens/tokens.go
+++ b/tokens/tokens.go
@@ -26,29 +26,38 @@ type WithdrawalRequest struct {
 
 // AccountToken represents a token that is enabled on an account.
 type AccountToken struct {
-	ID             uint64              `json:"-" gorm:"primaryKey"`
-	AccountAddress string              `json:"-" gorm:"uniqueIndex:addressname;index;not null"`
+	ID             uint64              `json:"-" gorm:"column:id;primaryKey"`
+	AccountAddress string              `json:"-" gorm:"column:account_address;uniqueIndex:addressname;index;not null"`
 	Account        accounts.Account    `json:"-" gorm:"foreignKey:AccountAddress;references:Address;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
-	TokenName      string              `json:"name" gorm:"uniqueIndex:addressname;index;not null"`
-	TokenAddress   string              `json:"address" gorm:"uniqueIndex:addressname;index;not null"`
-	TokenType      templates.TokenType `json:"-"`
-	CreatedAt      time.Time           `json:"-"`
-	UpdatedAt      time.Time           `json:"-"`
-	DeletedAt      gorm.DeletedAt      `json:"-" gorm:"index"`
+	TokenName      string              `json:"name" gorm:"column:token_name;uniqueIndex:addressname;index;not null"`
+	TokenAddress   string              `json:"address" gorm:"column:token_address;uniqueIndex:addressname;index;not null"`
+	TokenType      templates.TokenType `json:"-" gorm:"column:token_type"`
+	CreatedAt      time.Time           `json:"-" gorm:"column:created_at"`
+	UpdatedAt      time.Time           `json:"-" gorm:"column:updated_at"`
+	DeletedAt      gorm.DeletedAt      `json:"-" gorm:"column:deleted_at;index"`
+}
+
+func (AccountToken) TableName() string {
+	return "account_tokens"
 }
 
 // TokenTransfer is used for database interfacing
 type TokenTransfer struct {
-	ID               uint64                   `json:"-" gorm:"primaryKey"`
-	TransactionId    string                   `json:"transactionId"`
-	Transaction      transactions.Transaction `json:"-" gorm:"foreignKey:TransactionId;references:TransactionId;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
-	RecipientAddress string                   `json:"recipient" gorm:"index"`
-	FtAmount         string                   `json:"amount"`
-	NftID            uint64                   `json:"nftId"`
-	TokenName        string                   `json:"token"`
-	CreatedAt        time.Time                `json:"createdAt"`
-	UpdatedAt        time.Time                `json:"updatedAt"`
-	DeletedAt        gorm.DeletedAt           `json:"-" gorm:"index"`
+	ID               uint64                   `gorm:"column:id;primaryKey"`
+	TransactionId    string                   `gorm:"column:transaction_id"` // TODO (latenssi): should propably be unique over this column
+	Transaction      transactions.Transaction `gorm:"foreignKey:TransactionId;references:TransactionId;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	RecipientAddress string                   `gorm:"column:recipient_address;index"`
+	SenderAddress    string                   `gorm:"column:sender_address;index"`
+	FtAmount         string                   `gorm:"column:ft_amount"`
+	NftID            uint64                   `gorm:"column:nft_id"`
+	TokenName        string                   `gorm:"column:token_name"`
+	CreatedAt        time.Time                `gorm:"column:created_at"`
+	UpdatedAt        time.Time                `gorm:"column:updated_at"`
+	DeletedAt        gorm.DeletedAt           `gorm:"column:deleted_at;index"`
+}
+
+func (TokenTransfer) TableName() string {
+	return "token_transfers"
 }
 
 // TokenTransferBase is used for JSON interfacing
@@ -70,7 +79,7 @@ type TokenWithdrawal struct {
 // TokenDeposit is used for JSON interfacing
 type TokenDeposit struct {
 	TokenTransferBase
-	PayerAddress string `json:"sender"`
+	SenderAddress string `json:"sender"`
 }
 
 func baseFromTransfer(t *TokenTransfer) TokenTransferBase {
@@ -94,6 +103,6 @@ func (t *TokenTransfer) Withdrawal() TokenWithdrawal {
 func (t *TokenTransfer) Deposit() TokenDeposit {
 	return TokenDeposit{
 		baseFromTransfer(t),
-		t.Transaction.PayerAddress,
+		t.SenderAddress,
 	}
 }

--- a/transactions/store_gorm.go
+++ b/transactions/store_gorm.go
@@ -10,12 +10,17 @@ type GormStore struct {
 }
 
 func NewGormStore(db *gorm.DB) *GormStore {
+	// Ignore migration errors
+
+	db.Migrator().RenameColumn(&Transaction{}, "payer_address", "proposer_address")
+
 	db.AutoMigrate(&Transaction{})
+
 	return &GormStore{db}
 }
 
 func (s *GormStore) Transactions(tType Type, address string, o datastore.ListOptions) (tt []Transaction, err error) {
-	q := &Transaction{PayerAddress: address, TransactionType: tType}
+	q := &Transaction{ProposerAddress: address, TransactionType: tType}
 	err = s.db.
 		Where(q).
 		Order("created_at desc").
@@ -26,7 +31,7 @@ func (s *GormStore) Transactions(tType Type, address string, o datastore.ListOpt
 }
 
 func (s *GormStore) Transaction(tType Type, address, txId string) (t Transaction, err error) {
-	q := &Transaction{PayerAddress: address, TransactionType: tType, TransactionId: txId}
+	q := &Transaction{ProposerAddress: address, TransactionType: tType, TransactionId: txId}
 	err = s.db.Where(q).First(&t).Error
 	return
 }


### PR DESCRIPTION
As per this change we needed to migrate away from the incorrect assumption that the payer is also the "sender" of a token transfer. 

- Renaming `PayerAddress` to `ProposerAddress` in `Transaction`
- Adding a `SenderAddress` column to `TokenTransfer`
- Migrating so changes should be invisible to users