### PR TITLE
Update spec URL for HTML docs (ReDoc)

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     </style>
   </head>
   <body>
-    <redoc spec-url="https://raw.githubusercontent.com/onflow/wallet-api/main/openapi.yml"></redoc>
+    <redoc spec-url="https://raw.githubusercontent.com/flow-hydraulics/flow-wallet-api/main/openapi.yml"></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
   </body>
 </html>


### PR DESCRIPTION
Use the new repo URL for the OpenAPI spec in the HTML docs.