### PR TITLE
Refactor event polling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: dev
 dev:
-	docker-compose up -d db emulator
+	docker-compose up -d db pgadmin emulator
 	docker-compose logs -f
 
 .PHONY: stop

--- a/chain_events/lib.go
+++ b/chain_events/lib.go
@@ -1,0 +1,8 @@
+package chain_events
+
+func min(x, y uint64) uint64 {
+	if x > y {
+		return y
+	}
+	return x
+}

--- a/chain_events/listener.go
+++ b/chain_events/listener.go
@@ -95,11 +95,10 @@ func (l *Listener) Start() *Listener {
 
 	if err := l.initHeight(); err != nil {
 		_, ok := err.(*LockError)
-		if ok {
-			// Skip LockError as it means another listener is already handling this
-		} else {
+		if !ok {
 			panic(err)
 		}
+		// Skip LockError as it means another listener is already handling this
 	}
 
 	// TODO (latenssi): should use random intervals instead
@@ -134,11 +133,10 @@ func (l *Listener) Start() *Listener {
 
 				if lockErr != nil {
 					_, ok := lockErr.(*LockError)
-					if ok {
-						// Skip on LockError as it means another listener is already handling this round
-						continue
+					if !ok {
+						l.handleError(lockErr)
 					}
-					l.handleError(lockErr)
+					// Skip on LockError as it means another listener is already handling this round
 				}
 			}
 		}

--- a/chain_events/listener.go
+++ b/chain_events/listener.go
@@ -94,8 +94,9 @@ func (l *Listener) Start() *Listener {
 	}
 
 	if err := l.initHeight(); err != nil {
-		if strings.Contains(err.Error(), "could not obtain lock on row") {
-			// Skip as another listener is already handling this
+		_, ok := err.(*LockError)
+		if ok {
+			// Skip LockError as it means another listener is already handling this
 		} else {
 			panic(err)
 		}
@@ -132,8 +133,9 @@ func (l *Listener) Start() *Listener {
 				})
 
 				if lockErr != nil {
-					if strings.Contains(lockErr.Error(), "could not obtain lock on row") {
-						// Skip as another listener is already handling this round
+					_, ok := lockErr.(*LockError)
+					if ok {
+						// Skip on LockError as it means another listener is already handling this round
 						continue
 					}
 					l.handleError(lockErr)

--- a/chain_events/store.go
+++ b/chain_events/store.go
@@ -4,3 +4,11 @@ package chain_events
 type Store interface {
 	LockedStatus(func(*ListenerStatus) error) error
 }
+
+type LockError struct {
+	Err error
+}
+
+func (e *LockError) Error() string {
+	return e.Err.Error()
+}

--- a/chain_events/store.go
+++ b/chain_events/store.go
@@ -2,6 +2,5 @@ package chain_events
 
 // Store manages data regarding tokens.
 type Store interface {
-	UpdateListenerStatus(s *ListenerStatus) error
-	GetListenerStatus() (*ListenerStatus, error)
+	LockedStatus(func(*ListenerStatus) error) error
 }

--- a/chain_events/store_gorm.go
+++ b/chain_events/store_gorm.go
@@ -1,6 +1,8 @@
 package chain_events
 
 import (
+	"strings"
+
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -18,7 +20,7 @@ func NewGormStore(db *gorm.DB) *GormStore {
 // It takes a function 'fn' as argument. In the context of 'fn' 'status' is locked.
 // Uses NOWAIT modifier on the lock so simultaneous requests can be ignored.
 func (s *GormStore) LockedStatus(fn func(status *ListenerStatus) error) error {
-	return s.db.Transaction(func(tx *gorm.DB) error {
+	txErr := s.db.Transaction(func(tx *gorm.DB) error {
 		status := ListenerStatus{}
 
 		if err := tx.Clauses(clause.Locking{Strength: "UPDATE", Options: "NOWAIT"}).FirstOrCreate(&status).Error; err != nil {
@@ -35,4 +37,11 @@ func (s *GormStore) LockedStatus(fn func(status *ListenerStatus) error) error {
 
 		return nil // commit
 	})
+
+	// Need to handle implementation specific error message
+	if txErr != nil && strings.Contains(txErr.Error(), "could not obtain lock on row") {
+		return &LockError{Err: txErr}
+	}
+
+	return txErr
 }

--- a/chain_events/store_gorm.go
+++ b/chain_events/store_gorm.go
@@ -2,6 +2,7 @@ package chain_events
 
 import (
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type GormStore struct {
@@ -13,11 +14,25 @@ func NewGormStore(db *gorm.DB) *GormStore {
 	return &GormStore{db}
 }
 
-func (s *GormStore) GetListenerStatus() (t *ListenerStatus, err error) {
-	err = s.db.FirstOrCreate(&t).Error
-	return
-}
+// LockedStatus runs a transaction on the database manipulating 'status' of type ListenerStatus.
+// It takes a function 'fn' as argument. In the context of 'fn' 'status' is locked.
+// Uses NOWAIT modifier on the lock so simultaneous requests can be ignored.
+func (s *GormStore) LockedStatus(fn func(status *ListenerStatus) error) error {
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		status := ListenerStatus{}
 
-func (s *GormStore) UpdateListenerStatus(t *ListenerStatus) error {
-	return s.db.Save(&t).Error
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE", Options: "NOWAIT"}).FirstOrCreate(&status).Error; err != nil {
+			return err // rollback
+		}
+
+		if err := fn(&status); err != nil {
+			return err // rollback
+		}
+
+		if err := tx.Save(&status).Error; err != nil {
+			return err // rollback
+		}
+
+		return nil // commit
+	})
 }

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -82,6 +82,16 @@ type Config struct {
 	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 	// For more info: https://pkg.go.dev/time#ParseDuration
 	TransactionTimeout time.Duration `env:"FLOW_WALLET_TRANSACTION_TIMEOUT" envDefault:"0"`
+
+	// Set the starting height for event polling. This won't have any effect if the value in
+	// database (chain_event_status[0].latest_height) is greater.
+	// If 0 (default) use latest block height if starting fresh (no previous value in database).
+	ChainListenerStartingHeight uint64 `env:"FLOW_WALLET_EVENTS_STARTING_HEIGHT" envDefault:"0"`
+	// Maximum number of blocks to check at once.
+	ChainListenerMaxBlocks uint64 `env:"FLOW_WALLET_EVENTS_MAX_BLOCKS" envDefault:"100"`
+	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+	// For more info: https://pkg.go.dev/time#ParseDuration
+	ChainListenerInterval time.Duration `env:"FLOW_WALLET_EVENTS_INTERVAL" envDefault:"10s"`
 }
 
 type Options struct {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.9"
 services:
   db:
     image: postgres:13-alpine
+    restart: unless-stopped
     ports:
       - "5432:5432"
     environment:
@@ -9,14 +10,23 @@ services:
       - POSTGRES_USER=wallet
       - POSTGRES_PASSWORD=wallet
 
+  pgadmin:
+    image: dpage/pgadmin4
+    restart: unless-stopped
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@example.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+    ports:
+      - "5050:80"
+
   wallet:
     build:
       context: .
       dockerfile: ./docker/wallet/Dockerfile
       network: host # docker build sometimes has problems fetching from alpine's CDN
+    restart: unless-stopped
     ports:
       - "3000:3000"
-    restart: unless-stopped
     env_file:
       - ./.env
     environment:
@@ -30,6 +40,7 @@ services:
 
   emulator:
     image: gcr.io/flow-container-registry/emulator:v0.23.0
+    restart: unless-stopped
     command: emulator -v
     ports:
       - "3569:3569"


### PR DESCRIPTION
- Resolves #177
- Locks the status row in database so only one poller can run at a time, others will just skip
- Makes *starting height*, *max blocks to check* and *polling interval* configurable