### PR TITLE
Add support for pre-signing a transaction

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -1,0 +1,6 @@
+package tests
+
+import "path"
+
+// Use test env config from project root by default.
+var testConfigPath = path.Join("..", ".env.test")

--- a/tests/internal/test/config.go
+++ b/tests/internal/test/config.go
@@ -1,0 +1,43 @@
+package test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/flow-hydraulics/flow-wallet-api/configs"
+	"github.com/onflow/flow-go-sdk"
+)
+
+var defaultConfig = "default.test.env.cfg"
+
+// LoadConfig accepts an optional config file to be loaded. If none provided,
+// it loads a default one.
+//
+// DatabaseType is always `sqlite`.
+//
+// Configured database DSN points to a file in tempdir created for given test
+// and it's automatically cleaned up by t.CleanUp() in the end of test run.
+//
+func LoadConfig(t *testing.T, cfgFile ...string) *configs.Config {
+	t.Helper()
+
+	opts := &configs.Options{defaultConfig}
+
+	// Allow optional override of config file
+	if len(cfgFile) == 1 {
+		opts.EnvFilePath = cfgFile[0]
+	} else if len(cfgFile) > 1 {
+		t.Fatalf("maximum of one config file allowed, got %d", len(cfgFile))
+	}
+
+	cfg, err := configs.ParseConfig(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg.DatabaseDSN = path.Join(t.TempDir(), "test.db")
+	cfg.DatabaseType = "sqlite"
+	cfg.ChainID = flow.Emulator
+
+	return cfg
+}

--- a/tests/internal/test/flow_client.go
+++ b/tests/internal/test/flow_client.go
@@ -1,0 +1,27 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/flow-hydraulics/flow-wallet-api/configs"
+	"github.com/onflow/flow-go-sdk/client"
+	"google.golang.org/grpc"
+)
+
+func NewFlowClient(t *testing.T, cfg *configs.Config) *client.Client {
+	fc, err := client.New(cfg.AccessAPIHost, grpc.WithInsecure())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	close := func() {
+		err := fc.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Cleanup(close)
+
+	return fc
+}

--- a/tests/internal/test/logger.go
+++ b/tests/internal/test/logger.go
@@ -1,0 +1,12 @@
+package test
+
+import (
+	"io"
+	"log"
+)
+
+var testLogger = log.New(io.Discard, "", log.LstdFlags)
+
+func Logger() *log.Logger {
+	return testLogger
+}

--- a/tests/internal/test/service.go
+++ b/tests/internal/test/service.go
@@ -1,0 +1,84 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flow-hydraulics/flow-wallet-api/accounts"
+	"github.com/flow-hydraulics/flow-wallet-api/configs"
+	"github.com/flow-hydraulics/flow-wallet-api/datastore/gorm"
+	"github.com/flow-hydraulics/flow-wallet-api/jobs"
+	"github.com/flow-hydraulics/flow-wallet-api/keys"
+	"github.com/flow-hydraulics/flow-wallet-api/keys/basic"
+	"github.com/flow-hydraulics/flow-wallet-api/templates"
+	"github.com/flow-hydraulics/flow-wallet-api/transactions"
+)
+
+type Services interface {
+	GetAccounts() *accounts.Service
+	GetTransactions() *transactions.Service
+}
+
+type svcs struct {
+	accountService     *accounts.Service
+	transactionService *transactions.Service
+}
+
+func GetServices(t *testing.T, cfg *configs.Config) Services {
+	t.Helper()
+
+	db, err := gorm.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbClose := func() { gorm.Close(db) }
+	t.Cleanup(dbClose)
+
+	fc := NewFlowClient(t, cfg)
+
+	jobStore := jobs.NewGormStore(db)
+	accountStore := accounts.NewGormStore(db)
+	keyStore := keys.NewGormStore(db)
+	txStore := transactions.NewGormStore(db)
+
+	templateStore := templates.NewGormStore(db)
+	templateService := templates.NewService(cfg, templateStore)
+
+	km := basic.NewKeyManager(cfg, keyStore, fc)
+
+	wp := jobs.NewWorkerPool(nil, jobStore, 100, 1)
+	wpStop := func() { wp.Stop() }
+	t.Cleanup(wpStop)
+
+	txService := transactions.NewService(cfg, txStore, km, fc, wp)
+	accountService := accounts.NewService(cfg, accountStore, km, fc, wp, txService, templateService)
+
+	ctx := context.Background()
+	err = accountService.InitAdminAccount(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// make sure all requested proposal keys are created
+	keyCount, err := km.InitAdminProposalKeys(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if keyCount != cfg.AdminProposalKeyCount {
+		t.Fatal("incorrect number of admin proposal keys")
+	}
+
+	return &svcs{
+		accountService:     accountService,
+		transactionService: txService,
+	}
+}
+
+func (s *svcs) GetAccounts() *accounts.Service {
+	return s.accountService
+}
+
+func (s *svcs) GetTransactions() *transactions.Service {
+	return s.transactionService
+}

--- a/tests/transaction_service_test.go
+++ b/tests/transaction_service_test.go
@@ -1,0 +1,78 @@
+package tests
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/flow-hydraulics/flow-wallet-api/templates"
+	"github.com/flow-hydraulics/flow-wallet-api/tests/internal/test"
+	"github.com/flow-hydraulics/flow-wallet-api/transactions"
+	"github.com/onflow/flow-go-sdk"
+)
+
+func Test_Transaction_Sign_By_Admin(t *testing.T) {
+	cfg := test.LoadConfig(t, testConfigPath)
+	txSvc := test.GetServices(t, cfg).GetTransactions()
+
+	tx, err := txSvc.Sign(context.Background(), cfg.AdminAddress, templates.Raw{}, transactions.General)
+	if err != nil {
+		t.Fatalf("expected err == nil, got %#v", err)
+	}
+
+	// Verify that when payer == authorizer, there's no payload envelope signatures.
+	if len(tx.PayloadSignatures) > 0 {
+		t.Fatalf("expected len(tx.PayloadSignatures) == 0, got %d", len(tx.PayloadSignatures))
+	}
+
+	// Verify presence of payment envelope signature.
+	if len(tx.EnvelopeSignatures) == 0 {
+		t.Fatal("expected len(tx.EnvelopeSignatures) > 0, got 0")
+	}
+
+	if !addressExists(cfg.AdminAddress, tx.EnvelopeSignatures) {
+		t.Fatalf("couldn't find signer's address from envelope signatures")
+	}
+}
+
+func Test_Transaction_Sign_By_AnotherAccount(t *testing.T) {
+	ctx := context.Background()
+	cfg := test.LoadConfig(t, testConfigPath)
+	svcs := test.GetServices(t, cfg)
+
+	_, acc, err := svcs.GetAccounts().Create(ctx, true)
+	if err != nil {
+		t.Fatalf("expected err == nil, got %#v", err)
+	}
+
+	tx, err := svcs.GetTransactions().Sign(ctx, acc.Address, templates.Raw{}, transactions.General)
+	if err != nil {
+		t.Fatalf("expected err == nil, got %#v", err)
+	}
+
+	// Verify that when payer != authorizer, there's payload envelope signature[s] present.
+	if len(tx.PayloadSignatures) == 0 {
+		t.Fatal("expected len(tx.PayloadSignatures) > 0, got 0")
+	}
+
+	// Verify that payload signature is signed by correct address.
+	if !addressExists(acc.Address, tx.PayloadSignatures) {
+		t.Fatalf("couldn't find signer's address from payload signatures")
+	}
+
+	// Verify presence of payment envelope signature[s].
+	if len(tx.EnvelopeSignatures) == 0 {
+		t.Fatal("expected len(tx.EnvelopeSignatures) > 0, got 0")
+	}
+}
+
+func addressExists(addr string, sigs []flow.TransactionSignature) bool {
+	addr = strings.TrimPrefix(addr, "0x")
+	for _, s := range sigs {
+		if s.Address.Hex() == addr {
+			return true
+		}
+	}
+
+	return false
+}

--- a/tests/transaction_service_test.go
+++ b/tests/transaction_service_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/onflow/flow-go-sdk"
 )
 
-func Test_Transaction_Sign_By_Admin(t *testing.T) {
+func Test_TransactionSignByAdmin(t *testing.T) {
 	cfg := test.LoadConfig(t, testConfigPath)
 	txSvc := test.GetServices(t, cfg).GetTransactions()
 
@@ -35,7 +35,7 @@ func Test_Transaction_Sign_By_Admin(t *testing.T) {
 	}
 }
 
-func Test_Transaction_Sign_By_AnotherAccount(t *testing.T) {
+func Test_TransactionSignByAnotherAccount(t *testing.T) {
 	ctx := context.Background()
 	cfg := test.LoadConfig(t, testConfigPath)
 	svcs := test.GetServices(t, cfg)


### PR DESCRIPTION
`transactions.Service.Sign()` crafts a Flow transaction and signs it
with given account key. It returns pre-signed transaction that can be
sent later separately.

This PR also suggests a new structure for integration tests so that they
are laid out more fine grained and can include a bit more support
code that is packaged separately.

The idea is that `tests` package holds all integration tests, whether
those test service implementations or fully e2e implementations via
REST API (such as corresponding signing endpoint in a follow-up PR).

Towards https://github.com/flow-hydraulics/flow-wallet-api/issues/159