### PR TITLE
Drop unused dependency from `accounts.Service`

### DIFF
--- a/accounts/service.go
+++ b/accounts/service.go
@@ -27,7 +27,6 @@ type Service struct {
 	fc           *client.Client
 	wp           *jobs.WorkerPool
 	transactions *transactions.Service
-	templates    *templates.Service
 	cfg          *configs.Config
 }
 
@@ -39,10 +38,9 @@ func NewService(
 	fc *client.Client,
 	wp *jobs.WorkerPool,
 	txs *transactions.Service,
-	tes *templates.Service,
 ) *Service {
 	// TODO(latenssi): safeguard against nil config?
-	return &Service{store, km, fc, wp, txs, tes, cfg}
+	return &Service{store, km, fc, wp, txs, cfg}
 }
 
 func (s *Service) InitAdminAccount(ctx context.Context) error {

--- a/main.go
+++ b/main.go
@@ -114,7 +114,7 @@ func runServer(cfg *configs.Config) {
 	templateService := templates.NewService(cfg, templateStore)
 	jobsService := jobs.NewService(jobStore)
 	transactionService := transactions.NewService(cfg, transactionStore, km, fc, wp)
-	accountService := accounts.NewService(cfg, accountStore, km, fc, wp, transactionService, templateService)
+	accountService := accounts.NewService(cfg, accountStore, km, fc, wp, transactionService)
 	tokenService := tokens.NewService(cfg, tokenStore, km, fc, transactionService, templateService, accountService)
 
 	debugService := debug.Service{

--- a/main_test.go
+++ b/main_test.go
@@ -158,16 +158,13 @@ func TestAccountServices(t *testing.T) {
 	keyStore := keys.NewGormStore(db)
 	txStore := transactions.NewGormStore(db)
 
-	templateStore := templates.NewGormStore(db)
-	templateService := templates.NewService(cfg, templateStore)
-
 	km := basic.NewKeyManager(cfg, keyStore, fc)
 
 	wp := jobs.NewWorkerPool(nil, jobStore, 100, 1)
 	defer wp.Stop()
 
 	txService := transactions.NewService(cfg, txStore, km, fc, wp)
-	service := accounts.NewService(cfg, accountStore, km, fc, wp, txService, templateService)
+	service := accounts.NewService(cfg, accountStore, km, fc, wp, txService)
 
 	t.Run("admin init", func(t *testing.T) {
 		ctx := context.Background()
@@ -272,9 +269,6 @@ func TestAccountHandlers(t *testing.T) {
 	keyStore := keys.NewGormStore(db)
 	txStore := transactions.NewGormStore(db)
 
-	templateStore := templates.NewGormStore(db)
-	templateService := templates.NewService(cfg, templateStore)
-
 	km := basic.NewKeyManager(cfg, keyStore, fc)
 
 	wp := jobs.NewWorkerPool(nil, jobStore, 100, 1)
@@ -282,7 +276,7 @@ func TestAccountHandlers(t *testing.T) {
 
 	store := accounts.NewGormStore(db)
 	txService := transactions.NewService(cfg, txStore, km, fc, wp)
-	service := accounts.NewService(cfg, store, km, fc, wp, txService, templateService)
+	service := accounts.NewService(cfg, store, km, fc, wp, txService)
 
 	h := handlers.NewAccounts(testLogger, service)
 
@@ -705,7 +699,7 @@ func TestTransactionHandlers(t *testing.T) {
 	transactionService := transactions.NewService(cfg, transactionStore, km, fc, wp)
 
 	accountStore := accounts.NewGormStore(db)
-	accountService := accounts.NewService(cfg, accountStore, km, fc, wp, transactionService, templateService)
+	accountService := accounts.NewService(cfg, accountStore, km, fc, wp, transactionService)
 
 	h := handlers.NewTransactions(testLogger, transactionService)
 
@@ -967,7 +961,7 @@ func TestTokenServices(t *testing.T) {
 	defer wp.Stop()
 
 	transactionService := transactions.NewService(cfg, transactionStore, km, fc, wp)
-	accountService := accounts.NewService(cfg, accountStore, km, fc, wp, transactionService, templateService)
+	accountService := accounts.NewService(cfg, accountStore, km, fc, wp, transactionService)
 	tokenService := tokens.NewService(cfg, tokenStore, km, fc, transactionService, templateService, accountService)
 
 	t.Run("admin init", func(t *testing.T) {
@@ -1160,7 +1154,7 @@ func TestTokenHandlers(t *testing.T) {
 	defer wp.Stop()
 
 	transactionService := transactions.NewService(cfg, transactionStore, km, fc, wp)
-	accountService := accounts.NewService(cfg, accountStore, km, fc, wp, transactionService, templateService)
+	accountService := accounts.NewService(cfg, accountStore, km, fc, wp, transactionService)
 	tokenService := tokens.NewService(cfg, tokenStore, km, fc, transactionService, templateService, accountService)
 
 	t.Run("admin init", func(t *testing.T) {
@@ -1703,7 +1697,7 @@ func TestNFTDeployment(t *testing.T) {
 	defer wp.Stop()
 
 	transactionService := transactions.NewService(cfg, transactionStore, km, fc, wp)
-	accountService := accounts.NewService(cfg, accountStore, km, fc, wp, transactionService, templateService)
+	accountService := accounts.NewService(cfg, accountStore, km, fc, wp, transactionService)
 	tokenService := tokens.NewService(cfg, tokenStore, km, fc, transactionService, templateService, accountService)
 
 	_, _, err = tokenService.DeployTokenContractForAccount(context.Background(), true, "ExampleNFT", cfg.AdminAddress)


### PR DESCRIPTION
`templates.Service` is an unused dependency for `accounts.Service`. Drop
it so there's one dependency less :)