### PR TITLE
Add transaction signing endpoint

### DIFF
--- a/handlers/transactions.go
+++ b/handlers/transactions.go
@@ -26,6 +26,11 @@ func (s *Transactions) Create() http.Handler {
 	return UseJson(h)
 }
 
+func (s *Transactions) Sign() http.Handler {
+	h := http.HandlerFunc(s.SignFunc)
+	return UseJson(h)
+}
+
 func (s *Transactions) Details() http.Handler {
 	return http.HandlerFunc(s.DetailsFunc)
 }

--- a/handlers/transactions_func.go
+++ b/handlers/transactions_func.go
@@ -127,7 +127,17 @@ func (s *Transactions) SignFunc(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	handleJsonResponse(rw, http.StatusCreated, tx.ToJSONResponse())
+	resp, err := tx.ToJSONResponse()
+	if err != nil {
+		err = &errors.RequestError{
+			StatusCode: http.StatusInternalServerError,
+			Err:        fmt.Errorf("cannot decode signed transaction"),
+		}
+		handleError(rw, s.log, err)
+		return
+	}
+
+	handleJsonResponse(rw, http.StatusCreated, resp)
 }
 
 func (s *Transactions) DetailsFunc(rw http.ResponseWriter, r *http.Request) {

--- a/handlers/transactions_func.go
+++ b/handlers/transactions_func.go
@@ -99,6 +99,37 @@ func (s *Transactions) CreateFunc(rw http.ResponseWriter, r *http.Request) {
 	handleJsonResponse(rw, http.StatusCreated, res)
 }
 
+func (s *Transactions) SignFunc(rw http.ResponseWriter, r *http.Request) {
+	err := checkNonEmptyBody(r)
+	if err != nil {
+		handleError(rw, s.log, err)
+		return
+	}
+
+	vars := mux.Vars(r)
+
+	var b templates.Raw
+
+	// Try to decode the request body into the struct.
+	err = json.NewDecoder(r.Body).Decode(&b)
+	if err != nil {
+		err = &errors.RequestError{
+			StatusCode: http.StatusBadRequest,
+			Err:        fmt.Errorf("invalid body: %#v", err),
+		}
+		handleError(rw, s.log, err)
+		return
+	}
+
+	tx, err := s.service.Sign(r.Context(), vars["address"], b, transactions.General)
+	if err != nil {
+		handleError(rw, s.log, err)
+		return
+	}
+
+	handleJsonResponse(rw, http.StatusCreated, tx.ToJSONResponse())
+}
+
 func (s *Transactions) DetailsFunc(rw http.ResponseWriter, r *http.Request) {
 	var (
 		transaction *transactions.Transaction

--- a/main.go
+++ b/main.go
@@ -175,6 +175,7 @@ func runServer(cfg *configs.Config) {
 
 	// Account raw transactions
 	if !cfg.DisableRawTransactions {
+		rv.Handle("/accounts/{address}/sign", transactionHandler.Sign()).Methods(http.MethodPost)                           // sign
 		rv.Handle("/accounts/{address}/transactions", transactionHandler.List()).Methods(http.MethodGet)                    // list
 		rv.Handle("/accounts/{address}/transactions", transactionHandler.Create()).Methods(http.MethodPost)                 // create
 		rv.Handle("/accounts/{address}/transactions/{transactionId}", transactionHandler.Details()).Methods(http.MethodGet) // details

--- a/main_test.go
+++ b/main_test.go
@@ -438,6 +438,7 @@ func TestAccountTransactionHandlers(t *testing.T) {
 	h := handlers.NewTransactions(testLogger, service)
 
 	router := mux.NewRouter()
+	router.Handle("/{address}/sign", h.Sign()).Methods(http.MethodPost)
 	router.Handle("/{address}/transactions", h.List()).Methods(http.MethodGet)
 	router.Handle("/{address}/transactions", h.Create()).Methods(http.MethodPost)
 	router.Handle("/{address}/transactions/{transactionId}", h.Details()).Methods(http.MethodGet)
@@ -618,6 +619,16 @@ func TestAccountTransactionHandlers(t *testing.T) {
 			url:      "/invalid-address/transactions/invalid-id",
 			expected: "not a valid address",
 			status:   http.StatusBadRequest,
+		},
+		{
+			name:        "sign ok",
+			method:      http.MethodPost,
+			contentType: "application/json",
+			body:        strings.NewReader(validHello),
+			url:         fmt.Sprintf("/%s/sign", cfg.AdminAddress),
+			expected:    `(?m)^{"code":".*","arguments":\[.*\],"referenceBlockId":"(0x)?[0-9a-f]+","gasLimit":\d+,"proposalKey":{"address":"(0x)?[0-9a-f]+","keyIndex":\d+,"sequenceNumber":\d+},"payer":"(0x)?[0-9a-f]+","authorizers":\[(("[(0x)?[0-9a-f]+"),?)*\],"payloadSignatures":(null|\[({"address":"(0x)?[0-9a-f]+","keyIndex":\d+,"signature":"[0-9a-f]+"},?)*\]),"envelopeSignatures":\[({"address":"(0x)?[0-9a-f]+","keyIndex":\d+,"signature":"[0-9a-f]+"},?)*\]}$`,
+			status:      http.StatusCreated,
+			sync:        true,
 		},
 	}
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -339,6 +339,26 @@ paths:
 
 
 # Account transactions
+  /accounts/{address}/sign:
+    post:
+      summary: Sign a raw transaction
+      description: |-
+        Sign a transaction with custodial account keys, without sending it. Signed transaction is returned in response (with signatures).
+      operationId: signRawTransaction
+      tags:
+        - Account Transactions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/script"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/signedTransaction"
 
   /accounts/{address}/transactions:
     parameters:
@@ -794,6 +814,71 @@ components:
         updatedAt:
           type: string
           example: "2021-04-27T05:49:53.211+00:00"
+
+    signedTransaction:
+      type: object
+      properties:
+        code:
+          type: string
+          example: "transaction(greeting: String) { prepare(signer: AuthAccount){} execute { log(greeting.concat(\", World!\")) }}"
+        arguments:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                example: "String"
+              value:
+                type: string
+                example: "Hello"
+        referenceBlockId:
+          type: string
+          example: "ff25699272a9f42b5268e1b9c80b40275ef772528d4dfe8aadb8e5aebdea9bd9"
+        gasLimit:
+          type: integer
+          example: 9999
+        proposalKey:
+          type: object
+          properties:
+            address:
+              type: string
+              example: "e245813137217658"
+            keyIndex:
+              type: integer
+              example: 0
+            sequenceNumber:
+              type: integer
+              example: 42
+        payer:
+          type: string
+          example: "f8d6e0586b0a20c7"
+        authorizers:
+          type: array
+          items:
+            type: string
+            example: "e245813137217658"
+        payloadSignatures:
+          type: array
+          items:
+            $ref: '#components/schemas/transactionSignature'
+        envelopeSignatures:
+          type: array
+          items:
+            $ref: '#components/schemas/transactionSignature'
+
+    transactionSignature:
+      type: object
+      properties:
+        address:
+          type: string
+          example: "e245813137217658"
+        keyIndex:
+          type: integer
+          example: 0
+        signature:
+          type: string
+          example: "e2beedaf426c414925a7757defa61d1169781f1d84bc713788767efae54c1e275dc353481fc386cf7a961415cf9e749c384fdec35f8af0fc93e20d2da8cc29ef"
 
     job:
       type: object

--- a/tests/account_handler_test.go
+++ b/tests/account_handler_test.go
@@ -1,0 +1,136 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/flow-hydraulics/flow-wallet-api/accounts"
+	"github.com/flow-hydraulics/flow-wallet-api/flow_helpers"
+	"github.com/flow-hydraulics/flow-wallet-api/handlers"
+	"github.com/flow-hydraulics/flow-wallet-api/tests/internal/test"
+	"github.com/flow-hydraulics/flow-wallet-api/transactions"
+	"github.com/gorilla/mux"
+	"github.com/onflow/flow-go-sdk"
+)
+
+func TestEmulatorAcceptsSignedTransaction(t *testing.T) {
+	cfg := test.LoadConfig(t, testConfigPath)
+	svcs := test.GetServices(t, cfg)
+
+	accHandler := handlers.NewAccounts(test.Logger(), svcs.GetAccounts())
+	txHandler := handlers.NewTransactions(test.Logger(), svcs.GetTransactions())
+
+	router := mux.NewRouter()
+	router.Handle("/", accHandler.Create()).Methods(http.MethodPost)
+	router.Handle("/{address}/sign", txHandler.Sign()).Methods(http.MethodPost)
+
+	// Create signing account.
+	var account accounts.Account
+	res := send(router, http.MethodPost, "/?sync=true", nil)
+	assertStatusCode(t, res, http.StatusCreated)
+	fromJsonBody(res, &account)
+
+	// Transaction:
+	code := "transaction(greeting: String) { prepare(signer: AuthAccount){} execute { log(greeting.concat(\", World!\")) }}"
+	args := "[{\"type\":\"String\",\"value\":\"Hello\"}]"
+
+	// Sign it.
+	body := bytes.NewBufferString(fmt.Sprintf("{\"code\":%q,\"arguments\":%s}", code, args))
+	res = send(router, http.MethodPost, fmt.Sprintf("/%s/sign", account.Address), body)
+	assertStatusCode(t, res, http.StatusCreated)
+
+	var txResp transactions.SignedTransactionJSONResponse
+	err := json.NewDecoder(res.Body).Decode(&txResp)
+	if err != nil {
+		t.Fatal("failed to decode transaction signing response")
+	}
+
+	tx := flow.NewTransaction().
+		SetScript([]byte(txResp.Code)).
+		SetReferenceBlockID(flow.HexToID(txResp.ReferenceBlockID)).
+		SetGasLimit(txResp.GasLimit).
+		SetProposalKey(flow.HexToAddress(txResp.ProposalKey.Address), txResp.ProposalKey.KeyIndex, txResp.ProposalKey.SequenceNumber).
+		SetPayer(flow.HexToAddress(txResp.Payer))
+
+	for _, arg := range txResp.Arguments {
+		tx.AddRawArgument(arg)
+	}
+
+	for _, a := range txResp.Authorizers {
+		tx.AddAuthorizer(flow.HexToAddress(a))
+	}
+
+	for _, s := range txResp.PayloadSignatures {
+		bs, err := hex.DecodeString(s.Signature)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tx.AddPayloadSignature(flow.HexToAddress(s.Address), s.KeyIndex, bs)
+	}
+
+	for _, s := range txResp.EnvelopeSignatures {
+		bs, err := hex.DecodeString(s.Signature)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tx.AddEnvelopeSignature(flow.HexToAddress(s.Address), s.KeyIndex, bs)
+	}
+
+	ctx := context.Background()
+	client := test.NewFlowClient(t, cfg)
+	_, err = flow_helpers.SendAndWait(ctx, client, *tx, 10*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertStatusCode(t *testing.T, res *http.Response, expected int) {
+	t.Helper()
+	if res.StatusCode != expected {
+		bs, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			panic(err)
+		}
+		t.Fatalf("expected HTTP response status code %d, got %d: %s", expected, res.StatusCode, string(bs))
+	}
+}
+
+func asJson(v interface{}) []byte {
+	if v == nil {
+		return nil
+	}
+	bs, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return bs
+}
+
+func fromJsonBody(res *http.Response, v interface{}) {
+	bs, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		panic(err)
+	}
+
+	err = json.Unmarshal(bs, v)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func send(router *mux.Router, method, path string, body io.Reader) *http.Response {
+	req := httptest.NewRequest(method, path, body)
+	req.Header.Set("content-type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	return rr.Result()
+}

--- a/transactions/service.go
+++ b/transactions/service.go
@@ -168,7 +168,7 @@ func (s *Service) Sign(c context.Context, proposerAddress string, raw templates.
 			return err
 		}
 
-		if proposerAddress == s.cfg.AdminAddress {
+		if flow_helpers.HexString(proposerAddress) == flow_helpers.HexString(s.cfg.AdminAddress) {
 			proposer, err = s.km.AdminProposalKey(ctx)
 			if err != nil {
 				return err


### PR DESCRIPTION
This adds `/accounts/{address}/sign` endpoint to provide functionality
for pre-signing a transaction to be sent separately.

Towards https://github.com/flow-hydraulics/flow-wallet-api/issues/159