### PR TITLE
Basic custom account create script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+main
 
 # Test binary, built with `go test -c`
 *.test
@@ -21,7 +22,13 @@ tmp/
 *.pid
 
 # Docker specific
-flow/
-api/
 .github/
 examples/
+
+# Not required for build
+flow/
+api-test-scripts/
+*.md
+*.svg
+*.html
+*.yml

--- a/Makefile
+++ b/Makefile
@@ -55,3 +55,7 @@ stop-emulator: emulator.pid
 
 emulator.pid:
 	@cd flow && { flow emulator & echo $$! > ../$@; }
+
+.PHONY: lint
+lint:
+	@golangci-lint run

--- a/accounts/service.go
+++ b/accounts/service.go
@@ -113,7 +113,7 @@ func (s *Service) Create(c context.Context, sync bool) (*jobs.Job, *Account, err
 			ctx = context.Background()
 		}
 
-		err := New(ctx, transaction, a, k, s.fc, s.km, s.cfg.TransactionTimeout)
+		err := New(ctx, transaction, a, k, s.fc, s.km, s.cfg)
 		jobResult.TransactionID = transaction.TransactionId // Update job result
 		if err != nil {
 			return err

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -59,7 +59,8 @@ type Config struct {
 
 	// -- Templates --
 
-	EnabledTokens []string `env:"FLOW_WALLET_ENABLED_TOKENS" envSeparator:","`
+	EnabledTokens           []string `env:"FLOW_WALLET_ENABLED_TOKENS" envSeparator:","`
+	ScriptPathCreateAccount string   `env:"FLOW_WALLET_SCRIPT_PATH_CREATE_ACCOUNT" envDefault:""`
 
 	// -- Workerpool --
 

--- a/flow/cadence/transactions/custom_create_account.cdc
+++ b/flow/cadence/transactions/custom_create_account.cdc
@@ -1,0 +1,5 @@
+transaction(publicKeys: [String], contracts: {String: String}) {
+	prepare(signer: AuthAccount) {
+		panic("Account initialized with custom script")
+	}
+}


### PR DESCRIPTION
This will add a config parameter for custom account create script: `FLOW_WALLET_SCRIPT_PATH_CREATE_ACCOUNT`
If you want to use the default script, leave this empty (either do not declare it or use "").

fixes #103 