### PR TITLE
Use AdminProposalKey again and make tests more deterministic, 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run emulator in background
         run: |
-          cd flow && flow emulator &
+          cd flow && flow emulator -b 100ms &
           sleep 1
           cd flow && flow project deploy --network=emulator --update=true
 
@@ -56,9 +56,7 @@ jobs:
           FLOW_WALLET_CHAIN_ID: "flow-emulator"
           FLOW_WALLET_ENCRYPTION_KEY: "faae4ed1c30f4e4555ee3a71f1044a8e"
           FLOW_WALLET_ENABLED_TOKENS: "FUSD:0xf8d6e0586b0a20c7:fusd,FlowToken:0x0ae53cb6e3f42a79:flowToken"
-        run: |
-          go test
-          go test ./...
+        run: go test ./... -p 1
 
   lint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,7 @@ reset: down dev
 
 .PHONY: run-tests
 run-tests:
-	@go test
-	@go test ./...
+	@go test ./... -p 1
 
 .PHONY: test
 test: start-emulator deploy run-tests

--- a/Makefile
+++ b/Makefile
@@ -54,4 +54,4 @@ stop-emulator: emulator.pid
 	@kill `cat $<` && rm $<
 
 emulator.pid:
-	@cd flow && { flow emulator & echo $$! > ../$@; }
+	@cd flow && { flow emulator -b 100ms & echo $$! > ../$@; }

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -31,7 +31,7 @@ func handleError(rw http.ResponseWriter, logger *log.Logger, err error) {
 
 	// Check for "record not found" database error
 	if strings.Contains(err.Error(), "record not found") {
-		http.Error(rw, "record not found", http.StatusNotFound)
+		http.Error(rw, err.Error(), http.StatusNotFound)
 		return
 	}
 

--- a/keys/basic/keys.go
+++ b/keys/basic/keys.go
@@ -174,7 +174,7 @@ func (s *KeyManager) AdminProposalKey(ctx context.Context) (keys.Authorizer, err
 
 	index, err := s.store.ProposalKey()
 	if err != nil {
-		return keys.Authorizer{}, err
+		return keys.Authorizer{}, fmt.Errorf("unable to get admin proposal key: %w", err)
 	}
 
 	acc, err := s.fc.GetAccount(ctx, adminAcc)

--- a/tests/internal/test/config.go
+++ b/tests/internal/test/config.go
@@ -21,7 +21,7 @@ var defaultConfig = "default.test.env.cfg"
 func LoadConfig(t *testing.T, cfgFile ...string) *configs.Config {
 	t.Helper()
 
-	opts := &configs.Options{defaultConfig} // nolint
+	opts := &configs.Options{EnvFilePath: defaultConfig}
 
 	// Allow optional override of config file
 	if len(cfgFile) == 1 {

--- a/tests/internal/test/flow.go
+++ b/tests/internal/test/flow.go
@@ -42,7 +42,7 @@ func NewFlowClient(t *testing.T, cfg *configs.Config) *client.Client {
 }
 
 func NewFlowAccount(t *testing.T, fc *client.Client, creatorAddress flow.Address, creatorKey *flow.AccountKey, creatorSigner crypto.Signer) *flow.Account {
-	seed := make([]byte, seed_length, seed_length) // nolint
+	seed := make([]byte, seed_length)
 	readRandom(t, seed)
 
 	privateKey, err := crypto.GeneratePrivateKey(crypto.ECDSA_P256, seed)

--- a/transactions/service.go
+++ b/transactions/service.go
@@ -272,7 +272,7 @@ func (s *Service) getProposalAuthorizer(ctx context.Context, proposerAddress str
 
 	var proposer keys.Authorizer
 	if proposerAddress == s.cfg.AdminAddress {
-		proposer, err = s.km.AdminAuthorizer(ctx)
+		proposer, err = s.km.AdminProposalKey(ctx)
 		if err != nil {
 			return keys.Authorizer{}, err
 		}

--- a/transactions/service.go
+++ b/transactions/service.go
@@ -48,23 +48,23 @@ func NewService(
 func (s *Service) Create(ctx context.Context, sync bool, proposerAddress string, code string, args []Argument, tType Type) (*jobs.Job, *Transaction, error) {
 	transaction, err := s.newTransaction(ctx, proposerAddress, code, args, tType)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("error while getting new transaction: %w", err)
 	}
 
 	if !sync {
 		err := s.store.InsertTransaction(transaction)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("error while inserting transaction in db: %w", err)
 		}
 
 		job, err := s.wp.CreateJob(TransactionJobType, transaction.TransactionId)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("error while creating job: %w", err)
 		}
 
 		err = s.wp.Schedule(job)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("error while scheduling job: %w", err)
 		}
 
 		return job, transaction, nil
@@ -199,7 +199,7 @@ func (s *Service) buildFlowTransaction(ctx context.Context, proposerAddress, cod
 	// Admin should always be the payer of the transaction fees.
 	payer, err := s.km.AdminAuthorizer(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error while getting admin authorizer for payer: %w", err)
 	}
 
 	proposer, err := s.getProposalAuthorizer(ctx, proposerAddress)
@@ -254,7 +254,7 @@ func (s *Service) newTransaction(ctx context.Context, proposerAddress string, co
 
 	flowTx, err := s.buildFlowTransaction(ctx, proposerAddress, code, args)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error while building transaction: %w", err)
 	}
 
 	tx.TransactionId = flowTx.ID().Hex()
@@ -274,12 +274,12 @@ func (s *Service) getProposalAuthorizer(ctx context.Context, proposerAddress str
 	if proposerAddress == s.cfg.AdminAddress {
 		proposer, err = s.km.AdminProposalKey(ctx)
 		if err != nil {
-			return keys.Authorizer{}, err
+			return keys.Authorizer{}, fmt.Errorf("error while getting admin authorizer: %w", err)
 		}
 	} else {
 		proposer, err = s.km.UserAuthorizer(ctx, flow.HexToAddress(proposerAddress))
 		if err != nil {
-			return keys.Authorizer{}, err
+			return keys.Authorizer{}, fmt.Errorf("error while getting user authorizer: %w", err)
 		}
 	}
 


### PR DESCRIPTION
- Bring back `AdminProposalKey` in transactions service. This is needed to allow usage of multiple admin keys.
- Clean up tests and run them with `-p 1` to disable parallel runs