### PR TITLE
Basic custom account create script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+main
 
 # Test binary, built with `go test -c`
 *.test
@@ -25,3 +26,11 @@ flow/
 api/
 .github/
 examples/
+
+# Not required for build
+flow/
+api-test-scripts/
+*.md
+*.svg
+*.html
+*.yml

--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,7 @@ stop-emulator: emulator.pid
 
 emulator.pid:
 	@cd flow && { flow emulator -b 100ms & echo $$! > ../$@; }
+
+.PHONY: lint
+lint:
+	@golangci-lint run

--- a/accounts/service.go
+++ b/accounts/service.go
@@ -3,6 +3,7 @@ package accounts
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/flow-hydraulics/flow-wallet-api/configs"
@@ -213,6 +214,16 @@ func (s *Service) createAccount(ctx context.Context) (*Account, string, error) {
 		SetProposalKey(adminAuthorizer.Address, adminAuthorizer.Key.Index, adminAuthorizer.Key.SequenceNumber).
 		SetPayer(adminAuthorizer.Address).
 		SetGasLimit(maxGasLimit)
+
+	// Check if we want to use a custom account create script
+	if s.cfg.ScriptPathCreateAccount != "" {
+		bytes, err := os.ReadFile(s.cfg.ScriptPathCreateAccount)
+		if err != nil {
+			return nil, "", err
+		}
+		// Overwrite the existing script
+		flowTx.SetScript(bytes)
+	}
 
 	// Payer signs the envelope
 	if err := flowTx.SignEnvelope(adminAuthorizer.Address, adminAuthorizer.Key.Index, adminAuthorizer.Signer); err != nil {

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -59,7 +59,8 @@ type Config struct {
 
 	// -- Templates --
 
-	EnabledTokens []string `env:"FLOW_WALLET_ENABLED_TOKENS" envSeparator:","`
+	EnabledTokens           []string `env:"FLOW_WALLET_ENABLED_TOKENS" envSeparator:","`
+	ScriptPathCreateAccount string   `env:"FLOW_WALLET_SCRIPT_PATH_CREATE_ACCOUNT" envDefault:""`
 
 	// -- Workerpool --
 

--- a/flow/cadence/transactions/custom_create_account.cdc
+++ b/flow/cadence/transactions/custom_create_account.cdc
@@ -1,0 +1,5 @@
+transaction(publicKeys: [String], contracts: {String: String}) {
+	prepare(signer: AuthAccount) {
+		panic("Account initialized with custom script")
+	}
+}


### PR DESCRIPTION
This will add a config parameter for custom account create script: `FLOW_WALLET_SCRIPT_PATH_CREATE_ACCOUNT`
If you want to use the default script, leave this empty (either do not declare it or use "").

fixes #103

Replaces PR #194 