### PR TITLE
Add context to workerpool, timeout to webhook

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,6 +26,7 @@ flow/
 api/
 .github/
 examples/
+docker/
 
 # Not required for build
 flow/

--- a/accounts/service.go
+++ b/accounts/service.go
@@ -272,14 +272,12 @@ func (s *Service) createAccount(ctx context.Context) (*Account, string, error) {
 	return account, flowTx.ID().String(), nil
 }
 
-func (s *Service) executeAccountCreateJob(j *jobs.Job) error {
+func (s *Service) executeAccountCreateJob(ctx context.Context, j *jobs.Job) error {
 	if j.Type != AccountCreateJobType {
 		return jobs.ErrInvalidJobType
 	}
 
 	j.ShouldSendNotification = true
-
-	ctx := context.Background()
 
 	a, txID, err := s.createAccount(ctx)
 	if err != nil {

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -79,7 +79,11 @@ type Config struct {
 	// too many transactions and find that the queue is often backlogged.
 	WorkerCount uint `env:"FLOW_WALLET_WORKER_COUNT" envDefault:"100"`
 	// Webhook endpoint to receive job status updates
-	JobStatusWebhook string `env:"FLOW_WALLET_JOB_STATUS_WEBHOOK" envDefault:""`
+	JobStatusWebhookUrl string `env:"FLOW_WALLET_JOB_STATUS_WEBHOOK" envDefault:""`
+	// Duration for which to wait for a response, if 0 wait indefinitely. Default: 30s.
+	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+	// For more info: https://pkg.go.dev/time#ParseDuration
+	JobStatusWebhookTimeout time.Duration `env:"FLOW_WALLET_JOB_STATUS_WEBHOOK_TIMEOUT" envDefault:"30s"`
 
 	// -- Google KMS --
 
@@ -89,7 +93,7 @@ type Config struct {
 
 	// -- Misc --
 
-	// Duration for which to wait for a transaction seal, if 0 wait indefinitely.
+	// Duration for which to wait for a transaction seal, if 0 wait indefinitely. Default: 0.
 	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 	// For more info: https://pkg.go.dev/time#ParseDuration
 	TransactionTimeout time.Duration `env:"FLOW_WALLET_TRANSACTION_TIMEOUT" envDefault:"0"`

--- a/jobs/jobs_test.go
+++ b/jobs/jobs_test.go
@@ -1,6 +1,7 @@
 package jobs
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -38,24 +39,27 @@ func (writer *dummyWriter) Write(p []byte) (n int, err error) {
 func TestScheduleSendNotification(t *testing.T) {
 	writer := &dummyWriter{T: t}
 
+	ctx, cancel := context.WithCancel(context.Background())
 	wp := WorkerPool{
-		executors: make(map[string]ExecutorFunc),
-		jobChan:   make(chan *Job, 1),
-		logger:    log.New(writer, "", 0),
-		store:     &dummyStore{},
+		context:       ctx,
+		cancelContext: cancel,
+		executors:     make(map[string]ExecutorFunc),
+		jobChan:       make(chan *Job, 1),
+		logger:        log.New(writer, "", 0),
+		store:         &dummyStore{},
 	}
 
-	WithJobStatusWebhook("http://localhost")(&wp)
+	WithJobStatusWebhook("http://localhost", time.Minute)(&wp)
 
 	sendNotificationCalled := false
 
-	wp.RegisterExecutor(SendJobStatusJobType, func(j *Job) error {
+	wp.RegisterExecutor(SendJobStatusJobType, func(ctx context.Context, j *Job) error {
 		j.ShouldSendNotification = false
 		sendNotificationCalled = true
 		return nil
 	})
 
-	wp.RegisterExecutor("TestJobType", func(j *Job) error {
+	wp.RegisterExecutor("TestJobType", func(ctx context.Context, j *Job) error {
 		j.ShouldSendNotification = true
 		return nil
 	})
@@ -100,18 +104,21 @@ func TestExecuteSendNotification(t *testing.T) {
 
 		writer := &dummyWriter{T: t}
 
+		ctx, cancel := context.WithCancel(context.Background())
 		wp := WorkerPool{
-			executors: make(map[string]ExecutorFunc),
-			jobChan:   make(chan *Job, 1),
-			logger:    log.New(writer, "", 0),
-			store:     &dummyStore{},
+			context:       ctx,
+			cancelContext: cancel,
+			executors:     make(map[string]ExecutorFunc),
+			jobChan:       make(chan *Job, 1),
+			logger:        log.New(writer, "", 0),
+			store:         &dummyStore{},
 		}
 
-		WithJobStatusWebhook(svr.URL)(&wp)
+		WithJobStatusWebhook(svr.URL, time.Minute)(&wp)
 
 		wp.RegisterExecutor(SendJobStatusJobType, wp.executeSendJobStatus)
 
-		wp.RegisterExecutor("TestJobType", func(j *Job) error {
+		wp.RegisterExecutor("TestJobType", func(ctx context.Context, j *Job) error {
 			j.ShouldSendNotification = true
 			return nil
 		})
@@ -148,18 +155,21 @@ func TestExecuteSendNotification(t *testing.T) {
 
 		writer := &dummyWriter{T: t}
 
+		ctx, cancel := context.WithCancel(context.Background())
 		wp := WorkerPool{
-			executors: make(map[string]ExecutorFunc),
-			jobChan:   make(chan *Job, 1),
-			logger:    log.New(writer, "", 0),
-			store:     &dummyStore{},
+			context:       ctx,
+			cancelContext: cancel,
+			executors:     make(map[string]ExecutorFunc),
+			jobChan:       make(chan *Job, 1),
+			logger:        log.New(writer, "", 0),
+			store:         &dummyStore{},
 		}
 
-		WithJobStatusWebhook(svr.URL)(&wp)
+		WithJobStatusWebhook(svr.URL, time.Minute)(&wp)
 
 		wp.RegisterExecutor(SendJobStatusJobType, wp.executeSendJobStatus)
 
-		wp.RegisterExecutor("TestJobType", func(j *Job) error {
+		wp.RegisterExecutor("TestJobType", func(ctx context.Context, j *Job) error {
 			j.ShouldSendNotification = true
 			return ErrPermanentFailure
 		})
@@ -188,18 +198,21 @@ func TestExecuteSendNotification(t *testing.T) {
 	t.Run("erroring job should not send", func(t *testing.T) {
 		writer := &dummyWriter{T: t}
 
+		ctx, cancel := context.WithCancel(context.Background())
 		wp := WorkerPool{
-			executors: make(map[string]ExecutorFunc),
-			jobChan:   make(chan *Job, 1),
-			logger:    log.New(writer, "", 0),
-			store:     &dummyStore{},
+			context:       ctx,
+			cancelContext: cancel,
+			executors:     make(map[string]ExecutorFunc),
+			jobChan:       make(chan *Job, 1),
+			logger:        log.New(writer, "", 0),
+			store:         &dummyStore{},
 		}
 
-		WithJobStatusWebhook("http://localhost")(&wp)
+		WithJobStatusWebhook("http://localhost", time.Minute)(&wp)
 
 		wp.RegisterExecutor(SendJobStatusJobType, wp.executeSendJobStatus)
 
-		wp.RegisterExecutor("TestJobType", func(j *Job) error {
+		wp.RegisterExecutor("TestJobType", func(ctx context.Context, j *Job) error {
 			j.ShouldSendNotification = true
 			return fmt.Errorf("test error")
 		})
@@ -224,18 +237,21 @@ func TestExecuteSendNotification(t *testing.T) {
 
 		writer := &dummyWriter{T: t}
 
+		ctx, cancel := context.WithCancel(context.Background())
 		wp := WorkerPool{
-			executors: make(map[string]ExecutorFunc),
-			jobChan:   make(chan *Job, 1),
-			logger:    log.New(writer, "", 0),
-			store:     &dummyStore{},
+			context:       ctx,
+			cancelContext: cancel,
+			executors:     make(map[string]ExecutorFunc),
+			jobChan:       make(chan *Job, 1),
+			logger:        log.New(writer, "", 0),
+			store:         &dummyStore{},
 		}
 
-		WithJobStatusWebhook(svr.URL)(&wp)
+		WithJobStatusWebhook(svr.URL, time.Minute)(&wp)
 
 		wp.RegisterExecutor(SendJobStatusJobType, wp.executeSendJobStatus)
 
-		wp.RegisterExecutor("TestJobType", func(j *Job) error {
+		wp.RegisterExecutor("TestJobType", func(ctx context.Context, j *Job) error {
 			j.ShouldSendNotification = true
 			return nil
 		})

--- a/jobs/options.go
+++ b/jobs/options.go
@@ -1,10 +1,13 @@
 package jobs
 
-import "net/url"
+import (
+	"net/url"
+	"time"
+)
 
 type WorkerPoolOption func(*WorkerPool)
 
-func WithJobStatusWebhook(u string) WorkerPoolOption {
+func WithJobStatusWebhook(u string, timeout time.Duration) WorkerPoolOption {
 	return func(wp *WorkerPool) {
 		if u == "" {
 			return
@@ -20,5 +23,6 @@ func WithJobStatusWebhook(u string) WorkerPoolOption {
 		}
 
 		wp.notificationConfig.jobStatusWebhookUrl = valid
+		wp.notificationConfig.jobStatusWebhookTimeout = timeout
 	}
 }

--- a/main.go
+++ b/main.go
@@ -106,7 +106,7 @@ func runServer(cfg *configs.Config) {
 		jobStore,
 		cfg.WorkerQueueCapacity,
 		cfg.WorkerCount,
-		jobs.WithJobStatusWebhook(cfg.JobStatusWebhook),
+		jobs.WithJobStatusWebhook(cfg.JobStatusWebhookUrl, cfg.JobStatusWebhookTimeout),
 	)
 	defer func() {
 		ls.Println("Stopping worker pool..")

--- a/tests/workerpool_test.go
+++ b/tests/workerpool_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -19,7 +20,7 @@ func Test_WorkerPoolExecutesJobWithSuccess(t *testing.T) {
 
 	executedWG := &sync.WaitGroup{}
 	jobType := "job"
-	jobFunc := func(j *jobs.Job) error {
+	jobFunc := func(ctx context.Context, j *jobs.Job) error {
 		defer executedWG.Done()
 		return nil
 	}
@@ -67,7 +68,7 @@ func Test_WorkerPoolExecutesJobWithError(t *testing.T) {
 
 	executedWG := &sync.WaitGroup{}
 	jobType := "job"
-	jobFunc := func(j *jobs.Job) error {
+	jobFunc := func(ctx context.Context, j *jobs.Job) error {
 		defer executedWG.Done()
 		return errors.New("test job executor error returned on purpose")
 	}
@@ -115,7 +116,7 @@ func Test_WorkerPoolExecutesJobWithPermanentError(t *testing.T) {
 
 	executedWG := &sync.WaitGroup{}
 	jobType := "job"
-	jobFunc := func(j *jobs.Job) error {
+	jobFunc := func(ctx context.Context, j *jobs.Job) error {
 		defer executedWG.Done()
 		return jobs.PermanentFailure(errors.New("test job executor error returned on purpose"))
 	}
@@ -162,7 +163,7 @@ func Test_WorkerPoolPicksUpInitJob(t *testing.T) {
 
 	executedWG := &sync.WaitGroup{}
 	jobType := "job"
-	jobFunc := func(j *jobs.Job) error {
+	jobFunc := func(ctx context.Context, j *jobs.Job) error {
 		defer executedWG.Done()
 		return nil
 	}
@@ -217,7 +218,7 @@ func Test_WorkerPoolPicksUpErroredJob(t *testing.T) {
 
 	executedWG := &sync.WaitGroup{}
 	jobType := "job"
-	jobFunc := func(j *jobs.Job) error {
+	jobFunc := func(ctx context.Context, j *jobs.Job) error {
 		defer executedWG.Done()
 		return nil
 	}
@@ -282,7 +283,7 @@ func Test_WorkerPoolDoesntPickupFailedJob(t *testing.T) {
 	jobStore := jobs.NewGormStore(db)
 
 	jobType := "job"
-	jobFunc := func(j *jobs.Job) error {
+	jobFunc := func(ctx context.Context, j *jobs.Job) error {
 		t.Fatal("failed job executed")
 		return nil
 	}

--- a/transactions/service.go
+++ b/transactions/service.go
@@ -319,14 +319,12 @@ func (s *Service) sendTransaction(ctx context.Context, tx *Transaction) error {
 	return nil
 }
 
-func (s *Service) executeTransactionJob(j *jobs.Job) error {
+func (s *Service) executeTransactionJob(ctx context.Context, j *jobs.Job) error {
 	if j.Type != TransactionJobType {
 		return jobs.ErrInvalidJobType
 	}
 
 	j.ShouldSendNotification = true
-
-	ctx := context.Background()
 
 	tx, err := s.store.Transaction(j.TransactionID)
 	if err != nil {


### PR DESCRIPTION
Previously the webhook functionality would prevent the application from exiting if the webhook endpoint does not respond to the request. This PR adds a timeout for the webhook request and adds a context to job execute functions, allowing cancellation of job executions from main.