### PR TITLE
Store public keys in database, fix missing algos for KMS keys

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -16,7 +16,7 @@ versioning. To address schema versioning,
 ## Structure for DB migrations
 
 Each migration must be created as a separate package under
-`migrations/internal`. The current pattern for package name is `m + <YYYYMMDD`
+`migrations/internal`. The current pattern for package name is `m + <YYYYMMDD>`
 - e.g. `m20210922`.
 
 In order to activate / register the migration, it must be added to migration

--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -23,7 +23,7 @@ const AccountTypeNonCustodial = "non-custodial"
 // Account struct represents a storable account.
 type Account struct {
 	Address   string          `json:"address" gorm:"primaryKey"`
-	Keys      []keys.Storable `json:"-" gorm:"foreignKey:AccountAddress;references:Address;constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"`
+	Keys      []keys.Storable `json:"keys" gorm:"foreignKey:AccountAddress;references:Address;constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"`
 	Type      AccountType     `json:"type" gorm:"default:custodial"`
 	CreatedAt time.Time       `json:"createdAt" `
 	UpdatedAt time.Time       `json:"updatedAt"`

--- a/accounts/service.go
+++ b/accounts/service.go
@@ -258,6 +258,7 @@ func (s *Service) createAccount(ctx context.Context) (*Account, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
+	encryptedAccountKey.PublicKey = accountKey.PublicKey.String()
 
 	// Store account and key
 	account.Keys = []keys.Storable{encryptedAccountKey}

--- a/accounts/service.go
+++ b/accounts/service.go
@@ -166,7 +166,7 @@ func (s *Service) DeleteNonCustodialAccount(_ context.Context, address string) e
 	return s.store.HardDeleteAccount(&a)
 }
 
-// Details returns a specific account.
+// Details returns a specific account, does not include private keys
 func (s *Service) Details(address string) (Account, error) {
 	// Check if the input is a valid address
 	address, err := flow_helpers.ValidateAddress(address, s.cfg.ChainID)
@@ -174,7 +174,17 @@ func (s *Service) Details(address string) (Account, error) {
 		return Account{}, err
 	}
 
-	return s.store.Account(address)
+	account, err := s.store.Account(address)
+	if err != nil {
+		return Account{}, err
+	}
+
+	// Strip the private keys
+	for i := range account.Keys {
+		account.Keys[i].Value = make([]byte, 0)
+	}
+
+	return account, nil
 }
 
 // createAccount creates a new account on the flow blockchain. It generates a

--- a/accounts/store_gorm.go
+++ b/accounts/store_gorm.go
@@ -23,7 +23,7 @@ func (s *GormStore) Accounts(o datastore.ListOptions) (aa []Account, err error) 
 }
 
 func (s *GormStore) Account(address string) (a Account, err error) {
-	err = s.db.First(&a, "address = ?", address).Error
+	err = s.db.Preload("Keys").First(&a, "address = ?", address).Error
 	return
 }
 

--- a/keys/google/google.go
+++ b/keys/google/google.go
@@ -46,9 +46,11 @@ func Generate(cfg *configs.Config, ctx context.Context, keyIndex, weight int) (*
 	f.Index = keyIndex
 
 	p := &keys.Private{
-		Index: keyIndex,
-		Type:  keys.AccountKeyTypeGoogleKMS,
-		Value: k.ResourceID(),
+		Index:    keyIndex,
+		Type:     keys.AccountKeyTypeGoogleKMS,
+		Value:    k.ResourceID(),
+		SignAlgo: pub.Algorithm(),
+		HashAlgo: h,
 	}
 
 	return f, p, nil

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -47,8 +47,9 @@ type Storable struct {
 	Index          int            `json:"index" gorm:"index"`
 	Type           string         `json:"type"`
 	Value          []byte         `json:"-"`
-	SignAlgo       string         `json:"-"`
-	HashAlgo       string         `json:"-"`
+	PublicKey      string         `json:"publicKey"`
+	SignAlgo       string         `json:"signAlgo"`
+	HashAlgo       string         `json:"hashAlgo"`
 	CreatedAt      time.Time      `json:"createdAt"`
 	UpdatedAt      time.Time      `json:"updatedAt"`
 	DeletedAt      gorm.DeletedAt `json:"-" gorm:"index"`

--- a/main_test.go
+++ b/main_test.go
@@ -259,8 +259,15 @@ func TestAccountServices(t *testing.T) {
 			t.Errorf("Account has an invalid address: '%s'", account.Address)
 		}
 
-		if len(account.Keys) != 0 {
-			t.Error("Account should not expose keys")
+		if len(account.Keys) == 0 {
+			t.Error("Account should expose public data on keys")
+		}
+
+		// All Value fields (containing a private key) should be empty
+		for _, k := range account.Keys {
+			if len(k.Value) != 0 {
+				t.Error("Account should not expose private key value")
+			}
 		}
 	})
 

--- a/migrations/internal/m20211118/migration.go
+++ b/migrations/internal/m20211118/migration.go
@@ -1,0 +1,43 @@
+package m20211118
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+const ID = "20211118"
+
+type Storable struct {
+	ID             int            `json:"-" gorm:"primaryKey"`
+	AccountAddress string         `json:"-" gorm:"index"`
+	Index          int            `json:"index" gorm:"index"`
+	Type           string         `json:"type"`
+	Value          []byte         `json:"-"`
+	PublicKey      string         `json:"publicKey"`
+	SignAlgo       string         `json:"signAlgo"`
+	HashAlgo       string         `json:"hashAlgo"`
+	CreatedAt      time.Time      `json:"createdAt"`
+	UpdatedAt      time.Time      `json:"updatedAt"`
+	DeletedAt      gorm.DeletedAt `json:"-" gorm:"index"`
+}
+
+func (Storable) TableName() string {
+	return "storable_keys"
+}
+
+func Migrate(tx *gorm.DB) error {
+	if err := tx.AutoMigrate(&Storable{}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func Rollback(tx *gorm.DB) error {
+	if err := tx.Migrator().DropColumn(&Storable{}, "PublicKey"); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -10,22 +10,22 @@ import (
 
 func List() []*gormigrate.Migration {
 	ms := []*gormigrate.Migration{
-		&gormigrate.Migration{
+		{
 			ID:       m20210922.ID,
 			Migrate:  m20210922.Migrate,
 			Rollback: m20210922.Rollback,
 		},
-		&gormigrate.Migration{
+		{
 			ID:       m20211005.ID,
 			Migrate:  m20211005.Migrate,
 			Rollback: m20211005.Rollback,
 		},
-		&gormigrate.Migration{
+		{
 			ID:       m20211015.ID,
 			Migrate:  m20211015.Migrate,
 			Rollback: m20211015.Rollback,
 		},
-		&gormigrate.Migration{
+		{
 			ID:       m20211118.ID,
 			Migrate:  m20211118.Migrate,
 			Rollback: m20211118.Rollback,

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -4,6 +4,7 @@ import (
 	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20210922"
 	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211005"
 	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211015"
+	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211118"
 	"github.com/go-gormigrate/gormigrate/v2"
 )
 
@@ -23,6 +24,11 @@ func List() []*gormigrate.Migration {
 			ID:       m20211015.ID,
 			Migrate:  m20211015.Migrate,
 			Rollback: m20211015.Rollback,
+		},
+		&gormigrate.Migration{
+			ID:       m20211118.ID,
+			Migrate:  m20211118.Migrate,
+			Rollback: m20211118.Rollback,
 		},
 	}
 	return ms

--- a/openapi.yml
+++ b/openapi.yml
@@ -2,7 +2,10 @@ openapi: 3.0.0
 
 info:
   title: Flow Wallet API
+  description: A REST HTTP service that allows a developer to integrate wallet functionality into a larger Flow application infrastructure
   version: 0.8.0
+  contact:
+    url: https://github.com/orgs/flow-hydraulics/teams/wallet
 
 servers:
   - url: http://localhost:3000/v1
@@ -176,6 +179,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/nonFungibleToken"
 
+
 # Transactions
 
   /transactions:
@@ -341,6 +345,7 @@ paths:
 
 
 # Account transactions
+
   /accounts/{address}/sign:
     post:
       summary: Sign a raw transaction
@@ -349,6 +354,8 @@ paths:
       operationId: signRawTransaction
       tags:
         - Account Transactions
+      parameters:
+        - $ref: "#/components/parameters/address"
       requestBody:
         content:
           application/json:
@@ -484,7 +491,6 @@ paths:
                   - $ref: "#/components/schemas/job"
                   - $ref: "#/components/schemas/transaction"
 
-
   /accounts/{address}/fungible-tokens/{tokenName}/withdrawals:
     parameters:
       - $ref: "#/components/parameters/address"
@@ -524,7 +530,6 @@ paths:
                 oneOf:
                   - $ref: "#/components/schemas/job"
                   - $ref: "#/components/schemas/transaction"
-
 
   /accounts/{address}/fungible-tokens/{tokenName}/withdrawals/{transactionId}:
     parameters:
@@ -790,17 +795,39 @@ components:
         api version called: v1
 
     account:
+      description: Response data for account info, private key NOT included
       type: object
+      x-examples:
+        example-1:
+          address: "0x179b6b1cb6755e31"
+          keys:
+            - index: 0
+              type: "local"
+              publicKey: "0xc885376ff315cc26e9740e5f5418c1e515cf690e590433a4774c2b9f4c522e7dbbb720b5049bed79820c66c8e6555997900579e6885b131180bb844cd87f4c62"
+              signAlgo: "ECDSA_P256"
+              hashAlgo: "SHA3_256"
+              createdAt: "2021-11-18T13:08:04.4236649+02:00"
+              updatedAt: "2021-11-18T13:08:04.4236649+02:00"
+          type: "custodial"
+          createdAt: "2021-11-18T13:08:04.4230401+02:00"
+          updatedAt: "2021-11-18T13:08:04.4230401+02:00"
       properties:
         address:
           type: string
           example: "0xf8d6e0586b0a20c7"
+        keys:
+          type: array
+          items:
+            $ref: "#/components/schemas/key"
         createdAt:
           type: string
+          minLength: 1
           example: "2021-04-27T05:49:53.211+00:00"
+          format: date-time
         updatedAt:
           type: string
-          example: "2021-04-27T05:49:53.211+00:00"
+          example: "2021-04-27T05:49:54.211+00:00"
+          format: date-time
 
     transactionEvent:
       type: object
@@ -1262,7 +1289,58 @@ components:
             type: integer
           example: [1,2,3]
 
+    key:
+      type: object
+      x-examples:
+        example-1:
+          index: 0
+          type: local
+          publicKey: "0xc885376ff315cc26e9740e5f5418c1e515cf690e590433a4774c2b9f4c522e7dbbb720b5049bed79820c66c8e6555997900579e6885b131180bb844cd87f4c62"
+          signAlgo: ECDSA_P256
+          hashAlgo: SHA3_256
+          createdAt: "2021-11-18T13:08:04.4236649+02:00"
+          updatedAt: "2021-11-18T13:08:04.4236649+02:00"
+      properties:
+        index:
+          type: number
+          minimum: 0
+        type:
+          $ref: "#/components/schemas/keyType"
+        publicKey:
+          type: string
+          minLength: 1
+        signAlgo:
+          type: string
+          minLength: 1
+        hashAlgo:
+          type: string
+          minLength: 1
+        createdAt:
+          type: string
+          minLength: 1
+          format: date-time
+          example: "2021-04-27T05:49:53.211+00:00"
+        updatedAt:
+          type: string
+          format: date-time
+          example: "2021-04-27T05:49:53.211+00:00"
+      required:
+        - index
+        - type
+        - publicKey
+        - signAlgo
+        - hashAlgo
+        - createdAt
+        - updatedAt
 
+    keyType:
+      type: string
+      enum:
+        - local
+        - aws_kms
+        - google_kms
+      example: local
+      minLength: 1
 
   parameters:
     limit:


### PR DESCRIPTION
Changes in this PR:
- public keys are stored in the database for custodial accounts at creation time, migration script included
- keys are returned in the account creation response (sync) & account details response, private keys are omitted
- keys stored in a KMS have hashAlgo & signAlgos set (they were `UNKNOWN` previously)
- fixed linter warning about redundant type from array


Resolves #97