### PR TITLE
Allow throttling the transaction send rate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,6 @@ FLOW_WALLET_ADMIN_PROPOSAL_KEY_COUNT=50
 # You can increase the number of workers if you're sending
 # too many transactions and find that the queue is often backlogged.
 # FLOW_WALLET_WORKER_COUNT=100 (default)
+
+# Max transactions per second, rate at which the service can submit transactions to Flow
+# FLOW_WALLET_MAX_TPS=10 (default)

--- a/accounts/options.go
+++ b/accounts/options.go
@@ -1,0 +1,11 @@
+package accounts
+
+import "go.uber.org/ratelimit"
+
+type ServiceOption func(*Service)
+
+func WithTxRatelimiter(limiter ratelimit.Limiter) ServiceOption {
+	return func(svc *Service) {
+		svc.txRateLimiter = limiter
+	}
+}

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -108,6 +108,9 @@ type Config struct {
 	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 	// For more info: https://pkg.go.dev/time#ParseDuration
 	ChainListenerInterval time.Duration `env:"FLOW_WALLET_EVENTS_INTERVAL" envDefault:"10s"`
+
+	// Max transactions per second, rate at which the service can submit transactions to Flow
+	TransactionMaxSendRate int `env:"FLOW_WALLET_MAX_TPS" envDefault:"10"`
 }
 
 type Options struct {

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/zeebo/blake3 v0.2.1 // indirect
 	go.uber.org/goleak v1.1.12
+	go.uber.org/ratelimit v0.2.0
 	golang.org/x/crypto v0.0.0-20211115234514-b4de73f9ece8 // indirect
 	golang.org/x/net v0.0.0-20211116231205-47ca1ff31462 // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
+github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9orim59UnfUTLRjMpd09C5uEVQ6RPGeCaVI=
+github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129/go.mod h1:rFgpPQZYZ8vdbc+48xibu8ALc3yeyd64IhHS+PU6Yyg=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -721,6 +723,8 @@ go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
+go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
+go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.0.0/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.1.12 h1:gZAh5/EyT/HQwlpkCy6wTpqfH9H8Lz8zbm3dZh+OyzA=
@@ -728,6 +732,8 @@ go.uber.org/goleak v1.1.12/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
+go.uber.org/ratelimit v0.2.0 h1:UQE2Bgi7p2B85uP5dC2bbRtig0C+OeNRnNEafLjsLPA=
+go.uber.org/ratelimit v0.2.0/go.mod h1:YYBV4e4naJvhpitQrWJu1vCpgB7CboMe0qhltKt6mUg=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=

--- a/transactions/options.go
+++ b/transactions/options.go
@@ -1,0 +1,11 @@
+package transactions
+
+import "go.uber.org/ratelimit"
+
+type ServiceOption func(*Service)
+
+func WithTxRatelimiter(limiter ratelimit.Limiter) ServiceOption {
+	return func(svc *Service) {
+		svc.txRateLimiter = limiter
+	}
+}

--- a/transactions/service.go
+++ b/transactions/service.go
@@ -296,7 +296,7 @@ func (s *Service) getProposalAuthorizer(ctx context.Context, proposerAddress str
 }
 
 func (s *Service) sendTransaction(ctx context.Context, tx *Transaction) error {
-	// TODO: we should "recreate" the transaction as proposal key sequnce numbering
+	// TODO: we should "recreate" the transaction as proposal key sequence numbering
 	// might have gotten out of sync by now (in async situations)
 
 	flowTx, err := flow.DecodeTransaction(tx.FlowTransaction)

--- a/transactions/service.go
+++ b/transactions/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/onflow/cadence"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/client"
+	"go.uber.org/ratelimit"
 	"google.golang.org/grpc/codes"
 )
 
@@ -21,11 +22,12 @@ const TransactionJobType = "transaction"
 
 // Service defines the API for transaction HTTP handlers.
 type Service struct {
-	store Store
-	km    keys.Manager
-	fc    *client.Client
-	wp    *jobs.WorkerPool
-	cfg   *configs.Config
+	store         Store
+	km            keys.Manager
+	fc            *client.Client
+	wp            *jobs.WorkerPool
+	cfg           *configs.Config
+	txRateLimiter ratelimit.Limiter
 }
 
 // NewService initiates a new transaction service.
@@ -35,9 +37,16 @@ func NewService(
 	km keys.Manager,
 	fc *client.Client,
 	wp *jobs.WorkerPool,
+	opts ...ServiceOption,
 ) *Service {
+	var defaultTxRatelimiter = ratelimit.NewUnlimited()
+
 	// TODO(latenssi): safeguard against nil config?
-	svc := &Service{store, km, fc, wp, cfg}
+	svc := &Service{store, km, fc, wp, cfg, defaultTxRatelimiter}
+
+	for _, opt := range opts {
+		opt(svc)
+	}
 
 	// Register asynchronous job executor.
 	wp.RegisterExecutor(TransactionJobType, svc.executeTransactionJob)
@@ -287,6 +296,9 @@ func (s *Service) getProposalAuthorizer(ctx context.Context, proposerAddress str
 }
 
 func (s *Service) sendTransaction(ctx context.Context, tx *Transaction) error {
+	// TODO: we should "recreate" the transaction as proposal key sequnce numbering
+	// might have gotten out of sync by now (in async situations)
+
 	flowTx, err := flow.DecodeTransaction(tx.FlowTransaction)
 	if err != nil {
 		return err
@@ -308,6 +320,9 @@ func (s *Service) sendTransaction(ctx context.Context, tx *Transaction) error {
 
 		// The Flow transaction was not found. All good. Continue.
 	}
+
+	// Ratelimit
+	s.txRateLimiter.Take()
 
 	resp, err := flow_helpers.SendAndWait(ctx, s.fc, *flowTx, s.cfg.TransactionTimeout)
 	if err != nil {


### PR DESCRIPTION
- Add `FLOW_WALLET_MAX_TPS` env var to control max send rate, defaults to 10 (per second)
- Fix account creation proposal key errors

resolves #105 