### PR TITLE
Add idempotency middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ tmp/
 main
 
 flow/flowdb
+redis-data/

--- a/.gitignore
+++ b/.gitignore
@@ -139,4 +139,3 @@ tmp/
 main
 
 flow/flowdb
-redis-data/

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 
 .PHONY: dev
 dev:
-	@docker-compose up -d db pgadmin emulator
+	@docker-compose up -d db pgadmin emulator redis
 	@docker-compose logs -f
 
 .PHONY: stop

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ Examples:
 
 | Config variable | Environment variable        | Description                                                                                      | Default     | Examples                  |
 | --------------- | :-------------------------- | ------------------------------------------------------------------------------------------------ | ----------- | ------------------------- |
-| DatabaseType    | `FLOW_WALLET_DATABASE_TYPE` | Type of database driver                                                                          | `sqlite`    | `sqlite`, `psql`, `mysql` |
-| DatabaseDSN     | `FLOW_WALLET_DATABASE_DSN`  | Data source name ([DSN](https://en.wikipedia.org/wiki/Data_source_name)) for database connection | `wallet.db` | See below                 |
+| `DatabaseType`  | `FLOW_WALLET_DATABASE_TYPE` | Type of database driver                                                                          | `sqlite`    | `sqlite`, `psql`, `mysql` |
+| `DatabaseDSN`   | `FLOW_WALLET_DATABASE_DSN`  | Data source name ([DSN](https://en.wikipedia.org/wiki/Data_source_name)) for database connection | `wallet.db` | See below                 |
 
 Examples of Database DSN
 
@@ -166,12 +166,12 @@ export GOOGLE_APPLICATION_CREDENTIALS="/home/example/path/to/service-account-fil
 
 Configure Google KMS as the key storage for `flow-wallet-api` and set the necessary environment variables:
 
-| Config variable | Environment variable                 | Description      | Default | Examples                    |
-| --------------- | ------------------------------------ | ---------------- | ------- | --------------------------- |
-| DefaultKeyType  | `FLOW_WALLET_DEFAULT_KEY_TYPE`       | Default key type | `local` | `local`, `google_kms`       |
-| ProjectID       | `FLOW_WALLET_GOOGLE_KMS_PROJECT_ID`  | GCP Project ID   | -       | `flow-wallet-example`       |
-| LocationID      | `FLOW_WALLET_GOOGLE_KMS_LOCATION_ID` | GCP Location ID  | -       | `europe-north1`, `us-west1` |
-| KeyRingID       | `FLOW_WALLET_GOOGLE_KMS_KEYRING_ID`  | GCP Key Ring ID  | -       | `example-wallet-keyring`    |
+| Config variable  | Environment variable                 | Description      | Default | Examples                    |
+| ---------------- | ------------------------------------ | ---------------- | ------- | --------------------------- |
+| `DefaultKeyType` | `FLOW_WALLET_DEFAULT_KEY_TYPE`       | Default key type | `local` | `local`, `google_kms`       |
+| `ProjectID`      | `FLOW_WALLET_GOOGLE_KMS_PROJECT_ID`  | GCP Project ID   | -       | `flow-wallet-example`       |
+| `LocationID`     | `FLOW_WALLET_GOOGLE_KMS_LOCATION_ID` | GCP Location ID  | -       | `europe-north1`, `us-west1` |
+| `KeyRingID`      | `FLOW_WALLET_GOOGLE_KMS_KEYRING_ID`  | GCP Key Ring ID  | -       | `example-wallet-keyring`    |
 
 ### Google KMS for admin account
 
@@ -206,10 +206,10 @@ https://cloud.google.com/kms/docs/encrypt-decrypt#before_you_begin
 
 If you want to use an Google KMS symmetric encryption key for encrypting the stored account keys, please refer to the following configuration settings;
 
-| Config variable   | Environment variable              | Description                      | Default | Examples value for Google KMS                                                             |
-| ----------------- | --------------------------------- | -------------------------------- | ------- | ----------------------------------------------------------------------------------------- |
-| EncryptionKeyType | `FLOW_WALLET_ENCRYPTION_KEY_TYPE` | Encryption key type              | `local` | `google_kms`                                                                              |
-| EncryptionKey     | `FLOW_WALLET_ENCRYPTION_KEY`      | KMS encryption key resource name | -       | `projects/my-project/locations/us-west1/keyRings/my-keyring/cryptoKeys/my-encryption-key` |
+| Config variable     | Environment variable              | Description                      | Default | Examples value for Google KMS                                                             |
+| ------------------- | --------------------------------- | -------------------------------- | ------- | ----------------------------------------------------------------------------------------- |
+| `EncryptionKeyType` | `FLOW_WALLET_ENCRYPTION_KEY_TYPE` | Encryption key type              | `local` | `google_kms`                                                                              |
+| `EncryptionKey`     | `FLOW_WALLET_ENCRYPTION_KEY`      | KMS encryption key resource name | -       | `projects/my-project/locations/us-west1/keyRings/my-keyring/cryptoKeys/my-encryption-key` |
 
 ### AWS KMS setup
 
@@ -237,10 +237,10 @@ Configure AWS KMS as the key storage for `flow-wallet-api` and set the necessary
 
 If you want to use a key stored in AWS KMS for the admin account, please refer to the following configuration settings;
 
-| Config variable | Environment variable            | Description           | Default | Example value for AWS KMS                                                       |
-| --------------- | ------------------------------- | --------------------- | ------- | ------------------------------------------------------------------------------- |
-| AdminKeyType    | `FLOW_WALLET_ADMIN_KEY_TYPE`    | Admin key type        | `local` | `aws_kms`                                                                       |
-| AdminPrivateKey | `FLOW_WALLET_ADMIN_PRIVATE_KEY` | Admin private key ARN | -       | `arn:aws:kms:eu-central-1:012345678910:key/00000000-aaaa-bbbb-cccc-12345678910` |
+| Config variable   | Environment variable            | Description           | Default | Example value for AWS KMS                                                       |
+| ----------------- | ------------------------------- | --------------------- | ------- | ------------------------------------------------------------------------------- |
+| `AdminKeyType`    | `FLOW_WALLET_ADMIN_KEY_TYPE`    | Admin key type        | `local` | `aws_kms`                                                                       |
+| `AdminPrivateKey` | `FLOW_WALLET_ADMIN_PRIVATE_KEY` | Admin private key ARN | -       | `arn:aws:kms:eu-central-1:012345678910:key/00000000-aaaa-bbbb-cccc-12345678910` |
 
 When testing make sure to add the key to the admin account. You can convert the AWS public key (e.g. `aws.pem`) you downloaded/copied from AWS with flow-cli;
 
@@ -252,10 +252,28 @@ flow keys decode pem --from-file=aws.pem --sig-algo "ECDSA_secp256k1"
 
 If you want to use an AWS KMS symmetric encryption key for encrypting the stored account keys, please refer to the following configuration settings;
 
-| Config variable   | Environment variable              | Description            | Default | Examples value for AWS KMS                                                      |
-| ----------------- | --------------------------------- | ---------------------- | ------- | ------------------------------------------------------------------------------- |
-| EncryptionKeyType | `FLOW_WALLET_ENCRYPTION_KEY_TYPE` | Encryption key type    | `local` | `aws_kms`                                                                       |
-| EncryptionKey     | `FLOW_WALLET_ENCRYPTION_KEY`      | KMS encryption key ARN | -       | `arn:aws:kms:eu-central-1:012345678910:key/00000000-aaaa-bbbb-cccc-12345678910` |
+| Config variable     | Environment variable              | Description            | Default | Examples value for AWS KMS                                                      |
+| ------------------- | --------------------------------- | ---------------------- | ------- | ------------------------------------------------------------------------------- |
+| `EncryptionKeyType` | `FLOW_WALLET_ENCRYPTION_KEY_TYPE` | Encryption key type    | `local` | `aws_kms`                                                                       |
+| `EncryptionKey`     | `FLOW_WALLET_ENCRYPTION_KEY`      | KMS encryption key ARN | -       | `arn:aws:kms:eu-central-1:012345678910:key/00000000-aaaa-bbbb-cccc-12345678910` |
+
+
+### Idempotency middleware
+
+Idempotency middleware ensures that `POST` requests are idempotent. When the middleware is enabled an `Idempotency-Key` HTTP header is required for `POST` requests. The header value should be a unique identifier for the request (UUID or similar is recommended). Trying to send a request with a duplicate idempotency key will result in a `409 Conflict` HTTP response.
+
+To configure the middleware set the following configuration settings;
+
+| Config variable                     | Environment variable                               | Description                                      | Default | Examples                                             |
+| ----------------------------------- | -------------------------------------------------- | ------------------------------------------------ | ------- | ---------------------------------------------------- |
+| `DisableIdempotencyMiddleware`      | `FLOW_WALLET_DISABLE_IDEMPOTENCY_MIDDLEWARE`       | Disable the idempotency middleware entirely      | `false` | `true`, `false`                                      |
+| `IdempotencyMiddlewareDatabaseType` | `FLOW_WALLET_IDEMPOTENCY_MIDDLEWARE_DATABASE_TYPE` | Database type for idempotency key middleware     | `local` | `local`, `shared`, `redis`                           |
+| `IdempotencyMiddlewareRedisURL`     | `FLOW_WALLET_IDEMPOTENCY_MIDDLEWARE_REDIS_URL`     | Redis URL for idempotency key middleware storage | -       | `redis://walletapi:wallet-api-redis@localhost:6379/` |
+
+NOTE:
+- The `local` option for `IdempotencyMiddlewareDatabaseType` does not support multiple instances.
+- The provided `docker-compose.yml` provides a basic Redis instance for local development purposes, with basic configuration files in the [`redis-config`](redis-config) directory.
+- There is currently no automatic cleanup of old idempotency keys when using the `shared` (sql) database. Redis is recommended for production use.
 
 ### Log level
 

--- a/api-test-scripts/account.http
+++ b/api-test-scripts/account.http
@@ -8,11 +8,13 @@ content-type: application/json
 ### Create a new account (async)
 POST http://localhost:3000/v1/accounts HTTP/1.1
 content-type: application/json
+idempotency-key: {{$guid}}
 
 
 ### Create a new account (sync)
 POST http://localhost:3000/v1/accounts?sync=what-ever-non-empty HTTP/1.1
 content-type: application/json
+idempotency-key: ${{$guid}}
 
 
 ### Get account details

--- a/api-test-scripts/raw_transactions.http
+++ b/api-test-scripts/raw_transactions.http
@@ -19,6 +19,7 @@ content-type: application/json
 ### Transfer FLOW on testnet, admin -> custody account
 POST http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/transactions HTTP/1.1
 content-type: application/json
+idempotency-key: {{$guid}}
 
 {
   "code":"import FungibleToken from 0x9a0766d93b6608b7\nimport FlowToken from 0x7e60df042a9c0868\ntransaction(amount: UFix64, recipient: Address) {\nlet sentVault: @FungibleToken.Vault\n  prepare(signer: AuthAccount) {\n    let vaultRef = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n      ?? panic(\"failed to borrow reference to sender vault\")\n\n    self.sentVault <- vaultRef.withdraw(amount: amount)\n  }\n\n  execute {\n    let receiverRef =  getAccount(recipient)\n      .getCapability(/public/flowTokenReceiver)\n      .borrow<&{FungibleToken.Receiver}>()\n        ?? panic(\"failed to borrow reference to recipient vault\")\n\n    receiverRef.deposit(from: <-self.sentVault)\n  }\n}",
@@ -29,6 +30,7 @@ content-type: application/json
 ### Transfer FLOW on testnet, custody account -> admin
 POST http://localhost:3000/v1/accounts/{{testnetCustodyAccount}}/transactions HTTP/1.1
 content-type: application/json
+idempotency-key: {{$guid}}
 
 {
   "code":"import FungibleToken from 0x9a0766d93b6608b7\nimport FlowToken from 0x7e60df042a9c0868\ntransaction(amount: UFix64, recipient: Address) {\nlet sentVault: @FungibleToken.Vault\n  prepare(signer: AuthAccount) {\n    let vaultRef = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n      ?? panic(\"failed to borrow reference to sender vault\")\n\n    self.sentVault <- vaultRef.withdraw(amount: amount)\n  }\n\n  execute {\n    let receiverRef =  getAccount(recipient)\n      .getCapability(/public/flowTokenReceiver)\n      .borrow<&{FungibleToken.Receiver}>()\n        ?? panic(\"failed to borrow reference to recipient vault\")\n\n    receiverRef.deposit(from: <-self.sentVault)\n  }\n}",
@@ -42,6 +44,7 @@ content-type: application/json
 ### Transfer FLOW on emulator, admin -> custody account
 POST http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/transactions HTTP/1.1
 content-type: application/json
+idempotency-key: {{$guid}}
 
 {
   "code":"import FungibleToken from 0xee82856bf20e2aa6\nimport FlowToken from 0x0ae53cb6e3f42a79\ntransaction(amount: UFix64, recipient: Address) {\nlet sentVault: @FungibleToken.Vault\n  prepare(signer: AuthAccount) {\n    let vaultRef = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n      ?? panic(\"failed to borrow reference to sender vault\")\n\n    self.sentVault <- vaultRef.withdraw(amount: amount)\n  }\n\n  execute {\n    let receiverRef =  getAccount(recipient)\n      .getCapability(/public/flowTokenReceiver)\n      .borrow<&{FungibleToken.Receiver}>()\n        ?? panic(\"failed to borrow reference to recipient vault\")\n\n    receiverRef.deposit(from: <-self.sentVault)\n  }\n}",
@@ -51,6 +54,7 @@ content-type: application/json
 ### Transfer FLOW on emulator, custody account -> admin
 POST http://localhost:3000/v1/accounts/{{emulatorCustodyAccount}}/transactions HTTP/1.1
 content-type: application/json
+idempotency-key: {{$guid}}
 
 {
   "code":"import FungibleToken from 0xee82856bf20e2aa6\nimport FlowToken from 0x0ae53cb6e3f42a79\ntransaction(amount: UFix64, recipient: Address) {\nlet sentVault: @FungibleToken.Vault\n  prepare(signer: AuthAccount) {\n    let vaultRef = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)\n      ?? panic(\"failed to borrow reference to sender vault\")\n\n    self.sentVault <- vaultRef.withdraw(amount: amount)\n  }\n\n  execute {\n    let receiverRef =  getAccount(recipient)\n      .getCapability(/public/flowTokenReceiver)\n      .borrow<&{FungibleToken.Receiver}>()\n        ?? panic(\"failed to borrow reference to recipient vault\")\n\n    receiverRef.deposit(from: <-self.sentVault)\n  }\n}",
@@ -61,6 +65,7 @@ content-type: application/json
 ### Run "Hello world" transaction on emulator
 POST http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/transactions HTTP/1.1
 content-type: application/json
+idempotency-key: {{$guid}}
 
 {
   "code":"transaction(greeting: String) { prepare(signer: AuthAccount){} execute { log(greeting.concat(\", World!\")) }}",
@@ -70,6 +75,7 @@ content-type: application/json
 ### Mint ExampleNFT for admin account
 POST http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/transactions HTTP/1.1
 content-type: application/json
+idempotency-key: {{$guid}}
 
 {
   "code":"import NonFungibleToken from {{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}\nimport ExampleNFT from {{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}\ntransaction(recipient: Address) {\n    let minter: &ExampleNFT.NFTMinter\n    prepare(signer: AuthAccount) {\n        self.minter = signer\n            .borrow<&ExampleNFT.NFTMinter>(from: ExampleNFT.MinterStoragePath)\n            ?? panic(\"Could not borrow a reference to the NFT minter\")\n    }\n    execute {\n        let recipient = getAccount(recipient)\n        let receiver = recipient\n            .getCapability(ExampleNFT.CollectionPublicPath)!\n            .borrow<&{NonFungibleToken.CollectionPublic}>()\n            ?? panic(\"Could not get receiver reference to the NFT Collection\")\n        self.minter.mintNFT(recipient: receiver)\n    }\n}\n",

--- a/api-test-scripts/system.http
+++ b/api-test-scripts/system.http
@@ -4,6 +4,7 @@ GET http://localhost:3000/v1/system/settings HTTP/1.1
 ### Update system settings, leave out fields that should not be changed
 POST http://localhost:3000/v1/system/settings HTTP/1.1
 content-type: application/json
+idempotency-key: {{$guid}}
 
 {
   "maintenanceMode":false

--- a/api-test-scripts/tokens.http
+++ b/api-test-scripts/tokens.http
@@ -12,6 +12,7 @@ content-type: application/json
 ### Enable ExampleNFT
 POST http://localhost:3000/v1/tokens
 content-type: application/json
+idempotency-key: {{$guid}}
 
 {
   "name":"ExampleNFT",
@@ -65,6 +66,7 @@ content-type: application/json
 ### Create a FlowToken withdrawal from admin to custody account
 POST http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/fungible-tokens/FlowToken/withdrawals HTTP/1.1
 content-type: application/json
+idempotency-key: {{$guid}}
 
 {
   "recipient":"{{emulatorCustodyAccount}}",
@@ -74,6 +76,7 @@ content-type: application/json
 ### Create a FUSD withdrawal from admin to custody account
 POST http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/fungible-tokens/FUSD/withdrawals HTTP/1.1
 content-type: application/json
+idempotency-key: {{$guid}}
 
 {
   "recipient":"{{emulatorCustodyAccount}}",
@@ -83,6 +86,7 @@ content-type: application/json
 ### Create an ExampleNFT withdrawal from admin to custody account
 POST http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/non-fungible-tokens/ExampleNFT/withdrawals HTTP/1.1
 content-type: application/json
+idempotency-key: {{$guid}}
 
 {
   "recipient":"{{emulatorCustodyAccount}}",
@@ -112,14 +116,17 @@ content-type: application/json
 ### Setup FlowToken on emulator for admin account
 POST http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/fungible-tokens/FlowToken HTTP/1.1
 content-type: application/json
+idempotency-key: {{$guid}}
 
 ### Setup FUSD on emulator for admin account
 POST http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/fungible-tokens/FUSD HTTP/1.1
 content-type: application/json
+idempotency-key: {{$guid}}
 
 ### Setup ExampleNFT on emulator for admin account
 POST http://localhost:3000/v1/accounts/{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}/non-fungible-tokens/ExampleNFT HTTP/1.1
 content-type: application/json
+idempotency-key: {{$guid}}
 
 
 
@@ -146,6 +153,7 @@ content-type: application/json
 ### Create a FlowToken withdrawal from custody to admin account
 POST http://localhost:3000/v1/accounts/{{emulatorCustodyAccount}}/fungible-tokens/FlowToken/withdrawals HTTP/1.1
 content-type: application/json
+idempotency-key: {{$guid}}
 
 {
   "recipient":"{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}",
@@ -155,6 +163,7 @@ content-type: application/json
 ### Create a FUSD withdrawal from custody to admin account
 POST http://localhost:3000/v1/accounts/{{emulatorCustodyAccount}}/fungible-tokens/FUSD/withdrawals HTTP/1.1
 content-type: application/json
+idempotency-key: {{$guid}}
 
 {
   "recipient":"{{$dotenv FLOW_WALLET_ADMIN_ADDRESS}}",
@@ -192,11 +201,14 @@ content-type: application/json
 ### Setup FlowToken on emulator for custody account
 POST http://localhost:3000/v1/accounts/{{emulatorCustodyAccount}}/fungible-tokens/flowtoken HTTP/1.1
 content-type: application/json
+idempotency-key: {{$guid}}
 
 ### Setup FUSD on emulator for custody account
 POST http://localhost:3000/v1/accounts/{{emulatorCustodyAccount}}/fungible-tokens/FUSD HTTP/1.1
 content-type: application/json
+idempotency-key: {{$guid}}
 
 ### Setup ExampleNFT on emulator for custody account
 POST http://localhost:3000/v1/accounts/{{emulatorCustodyAccount}}/non-fungible-tokens/ExampleNFT HTTP/1.1
 content-type: application/json
+idempotency-key: {{$guid}}

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -120,6 +120,16 @@ type Config struct {
 	// For more info: https://pkg.go.dev/time#ParseDuration
 	TransactionTimeout time.Duration `env:"FLOW_WALLET_TRANSACTION_TIMEOUT" envDefault:"0"`
 
+	// Idempotency middleware configuration
+	DisableIdempotencyMiddleware bool `env:"FLOW_WALLET_DISABLE_IDEMPOTENCY_MIDDLEWARE" envDefault:"false"`
+	// Idempotency middleware database type;
+	// - "local", in-memory w/ no multi-instance support
+	// - "shared", sql (gorm) database shared with the app (DatabaseType)
+	// - "redis"
+	IdempotencyMiddlewareDatabaseType string `env:"FLOW_WALLET_IDEMPOTENCY_MIDDLEWARE_DATABASE_TYPE" envDefault:"local"`
+	// Redis URL for idempotency key storage, e.g. "redis://walletapi:wallet-api-redis@localhost:6379/"
+	IdempotencyMiddlewareRedisURL string `env:"FLOW_WALLET_IDEMPOTENCY_MIDDLEWARE_REDIS_URL" envDefault:""`
+
 	// Set the starting height for event polling. This won't have any effect if the value in
 	// database (chain_event_status[0].latest_height) is greater.
 	// If 0 (default) use latest block height if starting fresh (no previous value in database).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,17 @@ services:
       - POSTGRES_USER=wallet
       - POSTGRES_PASSWORD=wallet
 
+  redis:
+    image: redis:6.2-alpine
+    restart: unless-stopped
+    command: redis-server /usr/local/etc/redis/redis.conf
+    ports:
+      - "6379:6379"
+    volumes:
+      - ./redis-data:/data
+      - ./redis-config/redis.conf:/usr/local/etc/redis/redis.conf
+      - ./redis-config/users.acl:/usr/local/etc/redis/users.acl
+
   pgadmin:
     image: dpage/pgadmin4
     restart: unless-stopped
@@ -37,6 +48,7 @@ services:
     depends_on:
       - db
       - emulator
+      - redis
 
   emulator:
     image: gcr.io/flow-container-registry/emulator:v0.23.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     ports:
       - "6379:6379"
     volumes:
-      - ./redis-data:/data
+      - redis_data:/data
       - ./redis-config/redis.conf:/usr/local/etc/redis/redis.conf
       - ./redis-config/users.acl:/usr/local/etc/redis/users.acl
 
@@ -62,3 +62,6 @@ services:
       - FLOW_SERVICEPRIVATEKEY=${FLOW_WALLET_ADMIN_PRIVATE_KEY}
       - FLOW_SERVICEKEYSIGALGO=ECDSA_P256
       - FLOW_SERVICEKEYHASHALGO=SHA3_256
+
+volumes:
+  redis_data:

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/go-gormigrate/gormigrate/v2 v2.0.0
 	github.com/go-test/deep v1.0.8 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/gomodule/redigo v1.8.5 // indirect
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/handlers v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -313,6 +313,8 @@ github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golangci/lint-1 v0.0.0-20181222135242-d2cdd8c08219/go.mod h1:/X8TswGSh1pIozq4ZwCfxS0WA5JGXguxk94ar/4c87Y=
+github.com/gomodule/redigo v1.8.5 h1:nRAxCa+SVsyjSBrtZmG/cqb6VbTmuRzpg/PoTFlpumc=
+github.com/gomodule/redigo v1.8.5/go.mod h1:P9dn9mFrCBvWhGE1wpxx6fgq7BAeLBk+UUUzlpkBYO0=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/flatbuffers v1.11.0/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -37,6 +37,10 @@ func UseJson(h http.Handler) http.Handler {
 	return gorilla.ContentTypeHandler(h, "application/json")
 }
 
+func UseIdempotency(h http.Handler, opts IdempotencyHandlerOptions, store IdempotencyStore) http.Handler {
+	return IdempotencyHandler(h, opts, store)
+}
+
 // handleError is a helper function for unified HTTP error handling.
 func handleError(rw http.ResponseWriter, r *http.Request, err error) {
 	log.

--- a/handlers/idempotency.go
+++ b/handlers/idempotency.go
@@ -1,0 +1,207 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// Idempotency Handler middleware
+// ===========================================================================
+
+type IdempotencyStoreType int
+
+const (
+	IdempotencyStoreTypeLocal IdempotencyStoreType = iota
+	IdempotencyStoreTypeShared
+	IdempotencyStoreTypeRedis
+)
+
+func (ist IdempotencyStoreType) String() string {
+	return [...]string{"local", "shared", "redis"}[ist]
+}
+
+type IdempotencyHandlerOptions struct {
+	IgnorePaths []string
+	Expiry      time.Duration
+}
+
+type IdempotencyStore interface {
+	Get(key string) (bool, error)               // Get key by name, return bool "found" and possible error
+	Set(key string, expiry time.Duration) error // Set key by name & expiry in seconds, return possible error
+}
+
+// Redis store for idempotency keys
+type IdempotencyStoreRedis struct {
+	conn   redis.Conn
+	prefix string
+}
+
+func NewIdempotencyStoreRedis(c redis.Conn) *IdempotencyStoreRedis {
+	return &IdempotencyStoreRedis{conn: c, prefix: "idempotencykey"}
+}
+
+func (r *IdempotencyStoreRedis) prefixedKey(key string) string {
+	return fmt.Sprintf("%s:%s", r.prefix, key)
+}
+
+func (r *IdempotencyStoreRedis) Get(key string) (bool, error) {
+	keyExists, err := redis.Bool(r.conn.Do("EXISTS", r.prefixedKey(key)))
+	return keyExists, err
+}
+
+func (r *IdempotencyStoreRedis) Set(key string, expiry time.Duration) error {
+	res, err := r.conn.Do("PSETEX", r.prefixedKey(key), int(expiry.Milliseconds()), 1)
+	if err != nil {
+		return err
+	}
+
+	if res != "OK" {
+		return fmt.Errorf("failed to set key: %v", res)
+	}
+
+	return nil
+}
+
+// Gorm (SQL) store for idempotency keys
+type IdempotencyStoreGorm struct {
+	db *gorm.DB
+}
+
+// TODO: automatically expire/prune keys w/ ExpiryDate in the past
+type IdempotencyStoreGormItem struct {
+	Key        string    `gorm:"column:key;primary_key"`
+	ExpiryDate time.Time `gorm:"column:expiry_date"`
+}
+
+func (IdempotencyStoreGormItem) TableName() string {
+	return "idempotency_keys"
+}
+
+func NewIdempotencyStoreGorm(db *gorm.DB) *IdempotencyStoreGorm {
+	return &IdempotencyStoreGorm{db: db}
+}
+
+func (g *IdempotencyStoreGorm) Get(key string) (bool, error) {
+	item := IdempotencyStoreGormItem{}
+	err := g.db.First(&item, "key = ? and expiry_date > ?", key, time.Now()).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		// key doesn't exist
+		return false, nil
+	} else if err != nil {
+		// some other error
+		return false, err
+	}
+
+	// key exists
+	return true, nil
+}
+
+func (g *IdempotencyStoreGorm) Set(key string, expiry time.Duration) error {
+	// update expiry date if exists or create a new item
+	err := g.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "key"}},
+		DoUpdates: clause.AssignmentColumns([]string{"expiry_date"}),
+	}).Create(&IdempotencyStoreGormItem{Key: key, ExpiryDate: time.Now().Add(expiry)}).Error
+
+	if err != nil {
+		fmt.Println("error when creating IdempotecyStoreGormItem:", err)
+		return err
+	}
+
+	return nil
+}
+
+// Prune deletes all expired IdempotencyStoreGormItems from the database
+func (g *IdempotencyStoreGorm) Prune() error {
+	err := g.db.Delete(IdempotencyStoreGormItem{}, "expiry_date < ?", time.Now()).Error
+	return err
+}
+
+// Local / in-memory store for idempotency keys, mainly for testing purposes
+type IdempotencyStoreLocal struct {
+	keys map[string]time.Time // key: expiry
+}
+
+func NewIdempotencyStoreLocal() *IdempotencyStoreLocal {
+	return &IdempotencyStoreLocal{make(map[string]time.Time)}
+}
+
+func (m *IdempotencyStoreLocal) Get(key string) (bool, error) {
+	v, ok := m.keys[key]
+	if !ok {
+		return false, nil
+	}
+
+	// Still valid
+	if v.After(time.Now()) {
+		return true, nil
+	}
+
+	// Expired
+	// NOTE: item is removed as a side effect
+	if v.Before(time.Now()) {
+		delete(m.keys, key)
+		return false, nil
+	}
+
+	return false, nil
+}
+
+func (m *IdempotencyStoreLocal) Set(key string, expiry time.Duration) error {
+	dl := time.Now().Add(expiry)
+	m.keys[key] = dl
+
+	return nil
+}
+
+// IdempotencyHandler returns a http.HandlerFunc that checks
+// for request idempotency when applicable
+func IdempotencyHandler(h http.Handler, opts IdempotencyHandlerOptions, store IdempotencyStore) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		// Check for ignored paths
+		for _, path := range opts.IgnorePaths {
+			if strings.HasPrefix(r.URL.Path, path) {
+				h.ServeHTTP(rw, r)
+				return
+			}
+		}
+
+		// Only POST requests are checked
+		if r.Method != http.MethodPost {
+			h.ServeHTTP(rw, r)
+			return
+		}
+
+		key := r.Header.Get("Idempotency-Key")
+		if len(key) == 0 && r.Method == http.MethodPost {
+			http.Error(rw, "Idempotency-Key header not found", http.StatusBadRequest)
+			return
+		}
+
+		exists, err := store.Get(key)
+		if err != nil {
+			panic(err)
+		}
+
+		// XXX: same key w/ different payload should return 422,
+		// but isn't necessarily required functionality => only the key is stored
+		if exists {
+			http.Error(rw, fmt.Sprintf("Idempotency-Key conflict, key: %s", key), http.StatusConflict)
+			return
+		} else {
+			err := store.Set(key, opts.Expiry)
+			if err != nil {
+				panic(err)
+			}
+		}
+
+		h.ServeHTTP(rw, r)
+	})
+}

--- a/main.go
+++ b/main.go
@@ -246,7 +246,7 @@ func runServer(cfg *configs.Config) {
 		// Redis, separate from app db
 		case handlers.IdempotencyStoreTypeRedis.String():
 			if cfg.IdempotencyMiddlewareRedisURL == "" {
-				ls.Fatal("idempotency middleware db set to redis but Redis URL is empty")
+				log.Fatal("idempotency middleware db set to redis but Redis URL is empty")
 			}
 			pool := &redis.Pool{
 				MaxIdle:   80,
@@ -263,9 +263,9 @@ func runServer(cfg *configs.Config) {
 			client := pool.Get()
 
 			defer func() {
-				ls.Println("Closing Redis client..")
+				log.Info("Closing Redis client..")
 				if err := client.Close(); err != nil {
-					ls.Fatal(err)
+					log.Fatal(err)
 				}
 			}()
 

--- a/migrations/internal/m20211202/migration.go
+++ b/migrations/internal/m20211202/migration.go
@@ -1,0 +1,37 @@
+// m20211202 handles IdempotencyStoreGormItem migration
+// NOTE: IdempotencyStoreGormItems are used to store idempotency keys
+// when idempotency middleware is enabled & configured to use the shared sql database
+package m20211202
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+const ID = "20211202"
+
+type IdempotencyStoreGormItem struct {
+	Key        string    `gorm:"column:key;primary_key"`
+	ExpiryDate time.Time `gorm:"column:expiry_date"`
+}
+
+func (IdempotencyStoreGormItem) TableName() string {
+	return "idempotency_keys"
+}
+
+func Migrate(tx *gorm.DB) error {
+	if err := tx.AutoMigrate(&IdempotencyStoreGormItem{}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func Rollback(tx *gorm.DB) error {
+	if err := tx.Migrator().DropTable(&IdempotencyStoreGormItem{}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -6,6 +6,7 @@ import (
 	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211015"
 	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211118"
 	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211130"
+	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211202"
 	"github.com/go-gormigrate/gormigrate/v2"
 )
 
@@ -35,6 +36,11 @@ func List() []*gormigrate.Migration {
 			ID:       m20211130.ID,
 			Migrate:  m20211130.Migrate,
 			Rollback: m20211130.Rollback,
+		},
+		{
+			ID:       m20211202.ID,
+			Migrate:  m20211202.Migrate,
+			Rollback: m20211202.Rollback,
 		},
 	}
 	return ms

--- a/openapi.yml
+++ b/openapi.yml
@@ -70,6 +70,10 @@ paths:
                 x-examples:
                   example-1:
                     maintenanceMode: false
+              examples:
+                example-1:
+                  value:
+                    maintenanceMode: true
       operationId: get-system-settings
       description: Get system wide settings.
     post:
@@ -112,7 +116,13 @@ paths:
               x-examples:
                 example-1:
                   maintenanceMode: false
-        description: 'Post only fields you want to be changed.'
+            examples:
+              example-1:
+                value:
+                  maintenanceMode: true
+        description: Post only fields you want to be changed.
+      parameters:
+        - $ref: '#/components/parameters/idempotencyKey'
   /health/ready:
     get:
       summary: Healthcheck ready
@@ -221,6 +231,8 @@ paths:
       responses:
         '201':
           description: OK
+      parameters:
+        - $ref: '#/components/parameters/idempotencyKey'
   '/tokens/{id_or_name}':
     parameters:
       - name: id_or_name
@@ -422,6 +434,7 @@ paths:
         - Accounts
       parameters:
         - $ref: '#/components/parameters/sync'
+        - $ref: '#/components/parameters/idempotencyKey'
       responses:
         '201':
           description: Created
@@ -456,6 +469,7 @@ paths:
         - Account Transactions
       parameters:
         - $ref: '#/components/parameters/address'
+        - $ref: '#/components/parameters/idempotencyKey'
       requestBody:
         content:
           application/json:
@@ -499,6 +513,7 @@ paths:
         - Account Transactions
       parameters:
         - $ref: '#/components/parameters/sync'
+        - $ref: '#/components/parameters/idempotencyKey'
       requestBody:
         content:
           application/json:
@@ -574,6 +589,7 @@ paths:
         - Account Fungible Tokens
       parameters:
         - $ref: '#/components/parameters/sync'
+        - $ref: '#/components/parameters/idempotencyKey'
       responses:
         '201':
           description: OK
@@ -613,6 +629,7 @@ paths:
               $ref: '#/components/schemas/fungibleTokenWithdrawalRequest'
       parameters:
         - $ref: '#/components/parameters/sync'
+        - $ref: '#/components/parameters/idempotencyKey'
       responses:
         '201':
           description: OK
@@ -718,6 +735,7 @@ paths:
         - Account Non-Fungible Tokens
       parameters:
         - $ref: '#/components/parameters/sync'
+        - $ref: '#/components/parameters/idempotencyKey'
       responses:
         '201':
           description: OK
@@ -757,6 +775,7 @@ paths:
               $ref: '#/components/schemas/nonFungibleTokenWithdrawalRequest'
       parameters:
         - $ref: '#/components/parameters/sync'
+        - $ref: '#/components/parameters/idempotencyKey'
       responses:
         '201':
           description: OK
@@ -840,6 +859,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/account'
+      parameters:
+        - $ref: '#/components/parameters/idempotencyKey'
   '/watchlist/accounts/{address}':
     parameters:
       - $ref: '#/components/parameters/address'
@@ -1454,3 +1475,10 @@ components:
       schema:
         type: string
         example: something-non-empty
+    idempotencyKey:
+      name: Idempotency-Key
+      in: header
+      schema:
+        type: string
+        example: bec0a613-0d3b-4748-9e98-223a6ddb6a9f
+      description: Unique identifier for a request to guarantee idempotency for POST requests. Required when idempotency middleware is enabled.

--- a/redis-config/redis.conf
+++ b/redis-config/redis.conf
@@ -1,0 +1,20 @@
+bind 0.0.0.0
+protected-mode yes
+port 6379
+dir /data
+timeout 0
+stop-writes-on-bgsave-error no
+tcp-keepalive 300
+daemonize no
+supervised no
+pidfile /var/run/redis_6379.pid
+loglevel debug
+logfile ""
+databases 1
+always-show-logo no
+save 900 1
+save 300 10
+save 60 10000
+acllog-max-len 128
+aclfile /usr/local/etc/redis/users.acl
+appendonly no

--- a/redis-config/users.acl
+++ b/redis-config/users.acl
@@ -1,0 +1,1 @@
+user walletapi on ~* +@all >wallet-api-redis

--- a/tests/middleware_test.go
+++ b/tests/middleware_test.go
@@ -1,0 +1,61 @@
+package tests
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/flow-hydraulics/flow-wallet-api/handlers"
+	"github.com/gorilla/mux"
+)
+
+func Test_IdempotencyMiddleware(t *testing.T) {
+	is := handlers.NewIdempotencyStoreLocal()
+
+	// Dummy endpoint for testing
+	testHandler := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	})
+
+	router := mux.NewRouter()
+	router.Handle("/test", handlers.UseIdempotency(testHandler, handlers.IdempotencyHandlerOptions{
+		Expiry:      5000 * time.Millisecond,
+		IgnorePaths: []string{"/ignored"},
+	}, is)).Methods(http.MethodPost)
+
+	ik := "idempotency-key-test"
+	body := bytes.NewBufferString("")
+
+	t.Run("returns 200 with a fresh key", func(t *testing.T) {
+		res := sendWithHeaders(router, http.MethodPost, "/test", body, map[string]string{"Idempotency-Key": ik})
+		assertStatusCode(t, res, http.StatusOK)
+	})
+
+	t.Run("returns 409 with a used key", func(t *testing.T) {
+		res := sendWithHeaders(router, http.MethodPost, "/test", body, map[string]string{"Idempotency-Key": ik})
+		assertStatusCode(t, res, http.StatusConflict)
+	})
+
+	t.Run("returns 400 with missing header", func(t *testing.T) {
+		res := send(router, http.MethodPost, "/test", body)
+		assertStatusCode(t, res, http.StatusBadRequest)
+	})
+
+}
+
+// TODO: Move to test utils
+func sendWithHeaders(router *mux.Router, method, path string, body io.Reader, headers map[string]string) *http.Response {
+	req := httptest.NewRequest(method, path, body)
+	req.Header.Set("content-type", "application/json")
+
+	for hk, hv := range headers {
+		req.Header.Set(hk, hv)
+	}
+
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	return rr.Result()
+}


### PR DESCRIPTION
This adds basic idempotency middleware for `POST` endpoints:
- only the idempotency key is stored, so the payload is not examined when checking the received idempotency key and hence only `409` can be returned (key already used). A `422` response would require storing the payload.
- there are 3 supported "databases" (see README for configuration):
  - `local`: in-memory, single instance only, mainly for testing purposes
  - `shared`:  use the same db as main app
  - `redis`: use a separate Redis instance
- keys expire after 1 hour, meaning the same key can be used after >1 hour after previous usage
- key is expected to be sent in the `Idempotency-Key` header (OpenAPI spec has been updated accordingly)


Resolves #185 