### PR TITLE
Add type to account component

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -891,6 +891,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/key'
+        type:
+          type: string
+          example: 'custodial'
         createdAt:
           type: string
           minLength: 1


### PR DESCRIPTION
Added `type` to account component in openapi.yaml as it was missing.