### PR TITLE
Handle chain offline

### DIFF
--- a/accounts/service.go
+++ b/accounts/service.go
@@ -325,6 +325,8 @@ func (s *Service) createAccount(ctx context.Context) (*Account, string, error) {
 		Address: flow.HexToAddress(account.Address),
 	})
 
+	log.WithFields(log.Fields{"address": account.Address}).Debug("Account created")
+
 	return account, flowTx.ID().String(), nil
 }
 

--- a/chain_events/listener.go
+++ b/chain_events/listener.go
@@ -166,7 +166,11 @@ func (l *Listener) Start() *Listener {
 						// Unable to connect to chain, pause system.
 						if l.systemService != nil {
 							entry.Warn("Unable to connect to chain, pausing system")
-							l.systemService.Pause()
+							if err := l.systemService.Pause(); err != nil {
+								entry.
+									WithFields(log.Fields{"error": err}).
+									Warn("Unable to pause system")
+							}
 						} else {
 							entry.Warn("Unable to connect to chain")
 						}

--- a/chain_events/listener.go
+++ b/chain_events/listener.go
@@ -243,11 +243,7 @@ func (l *Listener) Stop() {
 
 func (l *Listener) systemHalted() (bool, error) {
 	if l.systemService != nil {
-		s, err := l.systemService.GetSettings()
-		if err != nil {
-			return false, err
-		}
-		return s.IsMaintenanceMode() || s.IsPaused(), nil
+		return l.systemService.IsHalted()
 	}
 	return false, nil
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,17 +51,21 @@ services:
       - redis
 
   emulator:
-    image: gcr.io/flow-container-registry/emulator:v0.23.0
+    image: gcr.io/flow-container-registry/emulator:0.27.2
     restart: unless-stopped
-    command: emulator -v
+    command: emulator -v --persist
     ports:
       - "3569:3569"
+    volumes:
+      - emulator_persist:/flowdb
     env_file:
       - ./.env
     environment:
       - FLOW_SERVICEPRIVATEKEY=${FLOW_WALLET_ADMIN_PRIVATE_KEY}
       - FLOW_SERVICEKEYSIGALGO=ECDSA_P256
       - FLOW_SERVICEKEYHASHALGO=SHA3_256
+      - FLOW_DBPATH=/flowdb
 
 volumes:
   redis_data:
+  emulator_persist:

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,6 +1,8 @@
 // Package errors provides an API for errors across the application.
 package errors
 
+import "strings"
+
 type RequestError struct {
 	StatusCode int
 	Err        error
@@ -8,4 +10,9 @@ type RequestError struct {
 
 func (e *RequestError) Error() string {
 	return e.Err.Error()
+}
+
+func IsChainConnectionError(err error) bool {
+	// TODO: check this properly
+	return strings.Contains(err.Error(), "connection refused")
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -2,6 +2,8 @@
 package errors
 
 import (
+	"net"
+
 	"github.com/onflow/flow-go-sdk/client"
 	"google.golang.org/grpc/codes"
 )
@@ -16,12 +18,17 @@ func (e *RequestError) Error() string {
 }
 
 var accessAPIConnectionErrors = []codes.Code{
+	codes.DeadlineExceeded,
 	codes.ResourceExhausted,
 	codes.Internal,
 	codes.Unavailable,
 }
 
 func IsChainConnectionError(err error) bool {
+	if _, ok := err.(net.Error); ok {
+		return true
+	}
+
 	if err, ok := err.(client.RPCError); ok {
 		// Check for Flow Access API connection errors
 		for _, code := range accessAPIConnectionErrors {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -2,21 +2,69 @@ package errors
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/onflow/flow-go-sdk/client"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
-func TestIsChainConnectionError(t *testing.T) {
-	fc, err := client.New("non-existent-address", grpc.WithInsecure())
-	if err != nil {
-		t.Fatal(err)
-	}
+type testNetError struct{}
 
-	if _, err := fc.GetLatestBlock(context.Background(), true); err == nil {
-		t.Fatal("expected an error")
-	} else if !IsChainConnectionError(err) {
-		t.Fatal("expected error to be a connection error")
-	}
+func (e *testNetError) Error() string   { return "NetError" }
+func (e *testNetError) Timeout() bool   { return false }
+func (e *testNetError) Temporary() bool { return false }
+
+func TestIsChainConnectionError(t *testing.T) {
+	t.Run("error cases", func(t *testing.T) {
+		var netErr error = &testNetError{}
+
+		valid_errors := []error{
+			netErr,
+			client.RPCError{
+				GRPCErr: status.Error(codes.DeadlineExceeded, "DeadlineExceeded"),
+			},
+			client.RPCError{
+				GRPCErr: status.Error(codes.ResourceExhausted, "ResourceExhausted"),
+			},
+			client.RPCError{
+				GRPCErr: status.Error(codes.Internal, "Internal"),
+			},
+			client.RPCError{
+				GRPCErr: status.Error(codes.Unavailable, "Unavailable"),
+			},
+		}
+
+		invalid_errors := []error{
+			fmt.Errorf("not a connection error"),
+		}
+
+		for _, err := range valid_errors {
+			if !IsChainConnectionError(err) {
+				t.Fatalf("expected error to be a connection error, got \"%s\"", err)
+			}
+		}
+
+		for _, err := range invalid_errors {
+			if IsChainConnectionError(err) {
+				t.Fatalf("expected error not to be a connection error, got \"%s\"", err)
+			}
+		}
+	})
+
+	t.Run("non existent gateway", func(t *testing.T) {
+		fc, err := client.New("non-existent-address", grpc.WithInsecure())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := fc.GetLatestBlock(context.Background(), true); err == nil {
+			t.Fatal("expected an error")
+		} else if !IsChainConnectionError(err) {
+			t.Fatal("expected error to be a connection error")
+		}
+	})
+
 }

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1,0 +1,22 @@
+package errors
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onflow/flow-go-sdk/client"
+	"google.golang.org/grpc"
+)
+
+func TestIsChainConnectionError(t *testing.T) {
+	fc, err := client.New("non-existent-address", grpc.WithInsecure())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := fc.GetLatestBlock(context.Background(), true); err == nil {
+		t.Fatal("expected an error")
+	} else if !IsChainConnectionError(err) {
+		t.Fatal("expected error to be a connection error")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/go-gormigrate/gormigrate/v2 v2.0.0
 	github.com/go-test/deep v1.0.8 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/gomodule/redigo v1.8.5 // indirect
+	github.com/gomodule/redigo v1.8.5
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/handlers v1.5.1

--- a/jobs/jobs_test.go
+++ b/jobs/jobs_test.go
@@ -61,7 +61,9 @@ func TestScheduleSendNotification(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wp.process(job)
+	if err := wp.process(job); err != nil {
+		t.Fatal(err)
+	}
 
 	if len(wp.jobChan) == 0 {
 		t.Fatal("expected job channel to contain a job")
@@ -73,7 +75,9 @@ func TestScheduleSendNotification(t *testing.T) {
 		t.Fatalf("expected pool to have a send_job_status job")
 	}
 
-	wp.process(sendNotificationJob)
+	if err := wp.process(sendNotificationJob); err != nil {
+		t.Fatal(err)
+	}
 
 	if !sendNotificationCalled {
 		t.Fatalf("expected 'sendNotificationCalled' to equal true")
@@ -120,8 +124,13 @@ func TestExecuteSendNotification(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		wp.process(job)
-		wp.process(<-wp.jobChan)
+		if err := wp.process(job); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := wp.process(<-wp.jobChan); err != nil {
+			t.Fatal(err)
+		}
 
 		if webhookJob.Type != "TestJobType" {
 			t.Fatalf("expected webhook endpoint to have received a notification")
@@ -171,8 +180,12 @@ func TestExecuteSendNotification(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		wp.process(job)
-		wp.process(<-wp.jobChan)
+		if err := wp.process(job); err != nil {
+			t.Fatal(err)
+		}
+		if err := wp.process(<-wp.jobChan); err != nil {
+			t.Fatal(err)
+		}
 
 		if webhookJob.Type != "TestJobType" {
 			t.Fatalf("expected webhook endpoint to have received a notification")
@@ -214,7 +227,9 @@ func TestExecuteSendNotification(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		wp.process(job)
+		if err := wp.process(job); err != nil {
+			t.Fatal(err)
+		}
 
 		if len(wp.jobChan) != 0 {
 			t.Errorf("did not expect a job to be queued")
@@ -253,9 +268,15 @@ func TestExecuteSendNotification(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		wp.process(job)
+		if err := wp.process(job); err != nil {
+			t.Fatal()
+		}
+
 		sendNotificationJob := <-wp.jobChan
-		wp.process(sendNotificationJob)
+
+		if err := wp.process(sendNotificationJob); err != nil {
+			t.Fatal(err)
+		}
 
 		if len(hook.Entries) != 1 {
 			t.Errorf("expected there to be one warning, got %d", len(hook.Entries))

--- a/jobs/options.go
+++ b/jobs/options.go
@@ -41,3 +41,27 @@ func WithLogger(logger *log.Logger) WorkerPoolOption {
 		wp.logger = logger
 	}
 }
+
+func WithMaxJobErrorCount(count int) WorkerPoolOption {
+	return func(wp *WorkerPool) {
+		wp.maxJobErrorCount = count
+	}
+}
+
+func WithDbJobPollInterval(d time.Duration) WorkerPoolOption {
+	return func(wp *WorkerPool) {
+		wp.dbJobPollInterval = d
+	}
+}
+
+func WithAcceptedGracePeriod(d time.Duration) WorkerPoolOption {
+	return func(wp *WorkerPool) {
+		wp.acceptedGracePeriod = d
+	}
+}
+
+func WithReSchedulableGracePeriod(d time.Duration) WorkerPoolOption {
+	return func(wp *WorkerPool) {
+		wp.reSchedulableGracePeriod = d
+	}
+}

--- a/jobs/workerpool.go
+++ b/jobs/workerpool.go
@@ -225,11 +225,7 @@ func (wp *WorkerPool) accept(job *Job) bool {
 
 func (wp *WorkerPool) systemHalted() (bool, error) {
 	if wp.systemService != nil {
-		s, err := wp.systemService.GetSettings()
-		if err != nil {
-			return false, err
-		}
-		return s.IsMaintenanceMode() || s.IsPaused(), nil
+		return wp.systemService.IsHalted()
 	}
 	return false, nil
 }

--- a/jobs/workerpool.go
+++ b/jobs/workerpool.go
@@ -301,7 +301,11 @@ func (wp *WorkerPool) startWorkers() {
 						if wp.systemService != nil {
 							entry.Warn("Unable to connect to chain, pausing system")
 							// Unable to connect to chain, pause system.
-							wp.systemService.Pause()
+							if err := wp.systemService.Pause(); err != nil {
+								entry.
+									WithFields(log.Fields{"error": err}).
+									Warn("Unable to pause system")
+							}
 						} else {
 							entry.Warn("Unable to connect to chain")
 						}

--- a/jobs/workerpool.go
+++ b/jobs/workerpool.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/flow-hydraulics/flow-wallet-api/datastore"
+	wallet_errors "github.com/flow-hydraulics/flow-wallet-api/errors"
 	"github.com/flow-hydraulics/flow-wallet-api/system"
 )
 
@@ -168,9 +169,11 @@ func (wp *WorkerPool) Schedule(j *Job) error {
 
 	entry.Debug("Scheduling job")
 
-	if wp.waitMaintenance() {
-		entry.Debug("In maintenance mode")
-		// In maintenance mode; prevent immediate scheduling and let dbScheduler handle this job
+	if halted, err := wp.systemHalted(); err != nil {
+		return fmt.Errorf("error while getting system settings: %w", err)
+	} else if halted {
+		// System halted; prevent immediate scheduling and let dbScheduler handle this job
+		entry.Debug("System halted")
 		return nil
 	}
 
@@ -220,8 +223,15 @@ func (wp *WorkerPool) accept(job *Job) bool {
 	return true
 }
 
-func (wp *WorkerPool) waitMaintenance() bool {
-	return wp.systemService != nil && wp.systemService.IsMaintenanceMode()
+func (wp *WorkerPool) systemHalted() (bool, error) {
+	if wp.systemService != nil {
+		s, err := wp.systemService.GetSettings()
+		if err != nil {
+			return false, err
+		}
+		return s.IsMaintenanceMode() || s.IsPaused(), nil
+	}
+	return false, nil
 }
 
 func (wp *WorkerPool) startDBJobScheduler() {
@@ -236,8 +246,13 @@ func (wp *WorkerPool) startDBJobScheduler() {
 				break jobPoolLoop
 			}
 
-			// Check for maintenance mode
-			if wp.waitMaintenance() {
+			if halted, err := wp.systemHalted(); err != nil {
+				wp.logger.
+					WithFields(log.Fields{"error": err}).
+					Warn("Could not get system settings from DB")
+				restTime = wp.dbJobPollInterval
+				continue
+			} else if halted {
 				restTime = wp.dbJobPollInterval
 				continue
 			}
@@ -273,7 +288,27 @@ func (wp *WorkerPool) startWorkers() {
 					break
 				}
 
-				wp.process(job)
+				if err := wp.process(job); err != nil {
+					// Handle critical processing errors
+
+					entry := job.logEntry(wp.logger.WithFields(log.Fields{
+						"package":  "jobs",
+						"function": "WorkerPool.startWorkers.goroutine",
+						"error":    err,
+					}))
+
+					if wallet_errors.IsChainConnectionError(err) {
+						if wp.systemService != nil {
+							entry.Warn("Unable to connect to chain, pausing system")
+							// Unable to connect to chain, pause system.
+							wp.systemService.Pause()
+						} else {
+							entry.Warn("Unable to connect to chain")
+						}
+					} else {
+						entry.Warn("Critical error while processing job")
+					}
+				}
 			}
 		}()
 	}
@@ -297,7 +332,7 @@ func (wp *WorkerPool) tryEnqueue(job *Job, block bool) bool {
 	}
 }
 
-func (wp *WorkerPool) process(job *Job) {
+func (wp *WorkerPool) process(job *Job) error {
 	entry := job.logEntry(wp.logger.WithFields(log.Fields{
 		"package":  "jobs",
 		"function": "WorkerPool.process",
@@ -305,41 +340,48 @@ func (wp *WorkerPool) process(job *Job) {
 
 	if !wp.accept(job) {
 		entry.Info("Failed to accept job")
-		return
+		return nil
 	}
 
 	executor, exists := wp.executors[job.Type]
 	if !exists {
 		entry.Warn("Could not process job, no registered executor for type")
+
 		job.State = NoAvailableWorkers
+
 		if err := wp.store.UpdateJob(job); err != nil {
-			entry.
-				WithFields(log.Fields{"error": err}).
-				Warn("Could not update DB entry for job")
+			return fmt.Errorf("error while updating database entry: %w", err)
 		}
-		return
+
+		return nil
 	}
 
-	err := executor(wp.context, job)
-	if err != nil {
+	if err := executor(wp.context, job); err != nil {
+		// Check for chain connection errors
+		if wallet_errors.IsChainConnectionError(err) {
+			// Stop processing this job any further, returning it to the pool.
+			return err
+		}
+
 		if job.ExecCount > wp.maxJobErrorCount || errors.Is(err, ErrPermanentFailure) {
 			job.State = Failed
 		} else {
 			job.State = Error
 		}
+
 		job.Error = err.Error()
+
 		entry.
 			WithFields(log.Fields{"error": err}).
 			Warn("Job execution resulted with error")
+
 	} else {
 		job.State = Complete
 		job.Error = ""
 	}
 
 	if err := wp.store.UpdateJob(job); err != nil {
-		entry.
-			WithFields(log.Fields{"error": err}).
-			Warn("Could not update DB entry for job")
+		return fmt.Errorf("error while updating database entry: %w", err)
 	}
 
 	if (job.State == Failed || job.State == Complete) && job.ShouldSendNotification && wp.notificationConfig.ShouldSendJobStatus() {
@@ -349,6 +391,8 @@ func (wp *WorkerPool) process(job *Job) {
 				Warn("Could not schedule a status update notification for job")
 		}
 	}
+
+	return nil
 }
 
 func (wp *WorkerPool) executeSendJobStatus(ctx context.Context, j *Job) error {

--- a/keys/basic/keys.go
+++ b/keys/basic/keys.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/flow-hydraulics/flow-wallet-api/configs"
 	"github.com/flow-hydraulics/flow-wallet-api/flow_helpers"
 	"github.com/flow-hydraulics/flow-wallet-api/keys"
@@ -197,6 +199,11 @@ func (s *KeyManager) AdminProposalKey(ctx context.Context) (keys.Authorizer, err
 	if err != nil {
 		return keys.Authorizer{}, err
 	}
+
+	log.WithFields(log.Fields{
+		"accountAddress": s.cfg.AdminAddress,
+		"keyIndex":       index,
+	}).Debug("Using admin proposal key")
 
 	return keys.Authorizer{
 		Address: adminAcc,

--- a/main_test.go
+++ b/main_test.go
@@ -141,6 +141,9 @@ func getTestApp(t *testing.T, cfg *configs.Config, ignoreLeaks bool) TestApp {
 
 	fc, err := client.New(cfg.AccessAPIHost, grpc.WithInsecure())
 	fatal(t, err)
+
+	fatal(t, fc.Ping(context.Background()))
+
 	t.Cleanup(func() {
 		fc.Close()
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -161,7 +161,14 @@ func getTestApp(t *testing.T, cfg *configs.Config, ignoreLeaks bool) TestApp {
 
 	km := basic.NewKeyManager(cfg, keyStore, fc)
 
-	wp := jobs.NewWorkerPool(jobStore, 5, 1)
+	wp := jobs.NewWorkerPool(
+		jobStore, 100, 1,
+		jobs.WithMaxJobErrorCount(0),
+		jobs.WithDbJobPollInterval(time.Second),
+		jobs.WithAcceptedGracePeriod(0),
+		jobs.WithReSchedulableGracePeriod(0),
+	)
+
 	t.Cleanup(func() {
 		wp.Stop()
 	})
@@ -303,17 +310,12 @@ func TestAccountServices(t *testing.T) {
 		job, _, err := app2.AccountService.Create(context.Background(), false)
 		fatal(t, err)
 
-		if job.State != jobs.Init && job.State != jobs.Accepted && job.State != jobs.Error {
-			t.Errorf("expected job status to be %s or %s or %s but got %s",
-				jobs.Init, jobs.Accepted, jobs.Error, job.State)
-		}
-
 		for job.State == jobs.Init || job.State == jobs.Accepted {
 			time.Sleep(10 * time.Millisecond)
 		}
 
-		if job.State != jobs.Error {
-			t.Fatalf("expected job status to be %s got %s", jobs.Error, job.State)
+		if job.State != jobs.Error && job.State != jobs.Failed {
+			t.Fatalf("expected job to have errored got %s", job.State)
 		}
 
 		expected := "Account initialized with custom script"

--- a/migrations/internal/m20211213/migration.go
+++ b/migrations/internal/m20211213/migration.go
@@ -1,0 +1,35 @@
+package m20211213
+
+import (
+	"database/sql"
+
+	"gorm.io/gorm"
+)
+
+const ID = "m20211213"
+
+type Settings struct {
+	gorm.Model
+	MaintenanceMode bool         `gorm:"column:maintenance_mode;default:false"`
+	PausedSince     sql.NullTime `gorm:"column:paused_since"`
+}
+
+func (Settings) TableName() string {
+	return "system_settings"
+}
+
+func Migrate(tx *gorm.DB) error {
+	if err := tx.AutoMigrate(&Settings{}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func Rollback(tx *gorm.DB) error {
+	if err := tx.Migrator().DropColumn(&Settings{}, "paused_since"); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -7,6 +7,7 @@ import (
 	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211118"
 	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211130"
 	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211202"
+	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211213"
 	"github.com/go-gormigrate/gormigrate/v2"
 )
 
@@ -41,6 +42,11 @@ func List() []*gormigrate.Migration {
 			ID:       m20211202.ID,
 			Migrate:  m20211202.Migrate,
 			Rollback: m20211202.Rollback,
+		},
+		{
+			ID:       m20211213.ID,
+			Migrate:  m20211213.Migrate,
+			Rollback: m20211213.Rollback,
 		},
 	}
 	return ms

--- a/openapi.yml
+++ b/openapi.yml
@@ -875,6 +875,16 @@ paths:
           description: OK
 components:
   schemas:
+    jobState:
+      type: string
+      example: ACCEPTED
+      enum:
+      - INIT
+      - ACCEPTED
+      - NO_AVAILABLE_WORKERS
+      - ERROR
+      - COMPLETE
+      - FAILED
     debugInfo:
       type: string
       example: |
@@ -1045,9 +1055,8 @@ components:
         jobId:
           type: string
           example: 717c25c2-4b54-4588-8f83-72f37ae1a0e8
-        status:
-          type: string
-          example: Accepted
+        state:
+          $ref: '#/components/schemas/jobState'
         result:
           type: string
           example: ''

--- a/openapi.yml
+++ b/openapi.yml
@@ -1057,6 +1057,9 @@ components:
           example: 717c25c2-4b54-4588-8f83-72f37ae1a0e8
         state:
           $ref: '#/components/schemas/jobState'
+        error:
+          type: string
+          example: ''
         result:
           type: string
           example: ''

--- a/system/options.go
+++ b/system/options.go
@@ -1,0 +1,13 @@
+package system
+
+import (
+	"time"
+)
+
+type ServiceOption func(*Service)
+
+func WithPauseDuration(duration time.Duration) ServiceOption {
+	return func(svc *Service) {
+		svc.pauseDuration = duration
+	}
+}

--- a/system/service.go
+++ b/system/service.go
@@ -1,7 +1,9 @@
 package system
 
 import (
+	"database/sql"
 	"fmt"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -26,16 +28,12 @@ func (svc *Service) SaveSettings(settings *Settings) error {
 	return svc.store.SaveSettings(settings)
 }
 
-func (svc *Service) IsMaintenanceMode() bool {
+func (svc *Service) Pause() error {
+	log.Trace("Pause system")
 	settings, err := svc.GetSettings()
 	if err != nil {
-		log.
-			WithFields(log.Fields{
-				"error":    err,
-				"package":  "system",
-				"function": "IsMaintenanceMode",
-			}).
-			Warn("Error while getting system settings")
+		return err
 	}
-	return err == nil && settings.MaintenanceMode
+	settings.PausedSince = sql.NullTime{Time: time.Now(), Valid: true}
+	return svc.SaveSettings(settings)
 }

--- a/system/system.go
+++ b/system/system.go
@@ -1,14 +1,19 @@
 package system
 
 import (
+	"database/sql"
 	"fmt"
+	"time"
 
 	"gorm.io/gorm"
 )
 
+const pauseDuration = time.Minute
+
 type Settings struct {
 	gorm.Model
-	MaintenanceMode bool `gorm:"column:maintenance_mode;default:false"`
+	MaintenanceMode bool         `gorm:"column:maintenance_mode;default:false"`
+	PausedSince     sql.NullTime `gorm:"column:paused_since"`
 }
 
 func (s *Settings) String() string {
@@ -24,6 +29,14 @@ func (s *Settings) ToJSON() SettingsJSON {
 	return SettingsJSON{
 		MaintenanceMode: s.MaintenanceMode,
 	}
+}
+
+func (s *Settings) IsMaintenanceMode() bool {
+	return s.MaintenanceMode
+}
+
+func (s *Settings) IsPaused() bool {
+	return s.PausedSince.Valid && s.PausedSince.Time.After(time.Now().Add(-pauseDuration))
 }
 
 // Update fields according to JSON version

--- a/system/system.go
+++ b/system/system.go
@@ -8,8 +8,6 @@ import (
 	"gorm.io/gorm"
 )
 
-const pauseDuration = time.Minute
-
 type Settings struct {
 	gorm.Model
 	MaintenanceMode bool         `gorm:"column:maintenance_mode;default:false"`
@@ -35,7 +33,7 @@ func (s *Settings) IsMaintenanceMode() bool {
 	return s.MaintenanceMode
 }
 
-func (s *Settings) IsPaused() bool {
+func (s *Settings) IsPaused(pauseDuration time.Duration) bool {
 	return s.PausedSince.Valid && s.PausedSince.Time.After(time.Now().Add(-pauseDuration))
 }
 

--- a/tests/accounts_service_test.go
+++ b/tests/accounts_service_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/flow-hydraulics/flow-wallet-api/accounts"
 	"github.com/flow-hydraulics/flow-wallet-api/jobs"
 	"github.com/flow-hydraulics/flow-wallet-api/tests/internal/test"
 )
@@ -116,30 +117,40 @@ func Test_Delete_Non_Custodial_Account_Is_Idempotent(t *testing.T) {
 	}
 }
 
-// Test if the service is able to simultaneously create multiple accounts
+// Test if the service is able to concurrently create multiple accounts
 func Test_Add_Multiple_New_Custodial_Accounts(t *testing.T) {
 	cfg := test.LoadConfig(t, testConfigPath)
-	svc := test.GetServices(t, cfg).GetAccounts()
+
+	instanceCount := 1
+	accountsToCreate := instanceCount * 5
+	// Worst case scenario where theoretically maximum number of transactions are done concurrently
+	cfg.WorkerCount = uint(accountsToCreate / instanceCount)
+
+	svcs := make([]*accounts.Service, instanceCount)
+
+	for i := 0; i < instanceCount; i++ {
+		svcs[i] = test.GetServices(t, cfg).GetAccounts()
+	}
 
 	if cfg.AdminProposalKeyCount <= 1 {
 		t.Skip("skipped as \"cfg.AdminProposalKeyCount\" is less than or equal to 1")
 	}
 
-	if acccounts, err := svc.List(0, 0); err != nil {
+	if acccounts, err := svcs[0].List(0, 0); err != nil {
 		t.Fatal(err)
 	} else if len(acccounts) > 1 {
 		t.Fatal("expected there to be only 1 account")
 	}
-
-	accountsToCreate := 3
 
 	wg := sync.WaitGroup{}
 	errChan := make(chan error, accountsToCreate*3)
 
 	for i := 0; i < accountsToCreate; i++ {
 		wg.Add(1)
-		go func() {
+		go func(i int, svcs []*accounts.Service) {
 			defer wg.Done()
+
+			svc := svcs[i%instanceCount]
 
 			job, _, err := svc.Create(context.Background(), false)
 			if err != nil {
@@ -151,7 +162,7 @@ func Test_Add_Multiple_New_Custodial_Accounts(t *testing.T) {
 				time.Sleep(100 * time.Millisecond)
 			}
 
-			if job.State == jobs.Error {
+			if job.State == jobs.Error || job.State == jobs.Failed {
 				errChan <- fmt.Errorf(job.Error)
 				return
 			}
@@ -160,7 +171,7 @@ func Test_Add_Multiple_New_Custodial_Accounts(t *testing.T) {
 				errChan <- err
 				return
 			}
-		}()
+		}(i, svcs)
 	}
 
 	wg.Wait()
@@ -171,7 +182,7 @@ func Test_Add_Multiple_New_Custodial_Accounts(t *testing.T) {
 	default:
 	}
 
-	if acccounts, err := svc.List(0, 0); err != nil {
+	if acccounts, err := svcs[0].List(0, 0); err != nil {
 		t.Fatal(err)
 	} else if len(acccounts) < 1+accountsToCreate {
 		t.Fatalf("expected there to be %d accounts", 1+accountsToCreate)

--- a/tests/internal/test/flow.go
+++ b/tests/internal/test/flow.go
@@ -29,6 +29,10 @@ func NewFlowClient(t *testing.T, cfg *configs.Config) *client.Client {
 		t.Fatal(err)
 	}
 
+	if err := fc.Ping(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
 	close := func() {
 		err := fc.Close()
 		if err != nil {

--- a/tests/internal/test/service.go
+++ b/tests/internal/test/service.go
@@ -66,7 +66,14 @@ func GetServices(t *testing.T, cfg *configs.Config) Services {
 
 	km := basic.NewKeyManager(cfg, keyStore, fc)
 
-	wp := jobs.NewWorkerPool(jobStore, 100, 1)
+	wp := jobs.NewWorkerPool(
+		jobStore, 100, 1,
+		jobs.WithMaxJobErrorCount(0),
+		jobs.WithDbJobPollInterval(time.Second),
+		jobs.WithAcceptedGracePeriod(0),
+		jobs.WithReSchedulableGracePeriod(0),
+	)
+
 	wpStop := func() { wp.Stop() }
 	t.Cleanup(wpStop)
 

--- a/tests/system_test.go
+++ b/tests/system_test.go
@@ -110,7 +110,7 @@ func TestIsPaused(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if settings.IsPaused() {
+	if settings.IsPaused(time.Minute) {
 		t.Error("expected system not to be paused")
 	}
 
@@ -125,7 +125,26 @@ func TestIsPaused(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !settings.IsPaused() {
+	if !settings.IsPaused(time.Minute) {
 		t.Error("expected system to be paused")
+	}
+}
+
+func TestPausing(t *testing.T) {
+	cfg := test.LoadConfig(t, testConfigPath)
+	svcs := test.GetServices(t, cfg)
+
+	sysService := svcs.GetSystem()
+
+	if halted, err := sysService.IsHalted(); err != nil || halted {
+		t.Error("expected system not to be halted")
+	}
+
+	if err := sysService.Pause(); err != nil {
+		t.Fatal(err)
+	}
+
+	if halted, err := sysService.IsHalted(); err != nil || !halted {
+		t.Error("expected system to be halted")
 	}
 }


### PR DESCRIPTION
If a job or event poll fails due to a flow AccessAPI connection error (GRPC error of `ResourceExhausted`, `Internal` or `Unavailable`), the system is paused.

- If the error happened during a job execution, the job will be returned to the pool.
- If the error happened during event polling, the system will retry the same blocks later. 

The system will be paused for 1 minute and no jobs or events will be handled during that time. After the grace period (1 minute), the system is resumed. 

In more detail, the system is paused by setting the `paused_since` timestamp on the system settings database table. 

TODO:
- ~Make sure we correctly detect chain offline situation~
- Add a test to for the grace period