### PR TITLE
Handle situation when chain is unreachable

### DIFF
--- a/chain_events/listener.go
+++ b/chain_events/listener.go
@@ -231,11 +231,7 @@ func (l *Listener) Stop() {
 
 func (l *Listener) systemHalted() (bool, error) {
 	if l.systemService != nil {
-		s, err := l.systemService.GetSettings()
-		if err != nil {
-			return false, err
-		}
-		return s.IsMaintenanceMode() || s.IsPaused(), nil
+		return l.systemService.IsHalted()
 	}
 	return false, nil
 }

--- a/chain_events/listener.go
+++ b/chain_events/listener.go
@@ -166,7 +166,11 @@ func (l *Listener) Start() *Listener {
 						// Unable to connect to chain, pause system.
 						if l.systemService != nil {
 							entry.Warn("Unable to connect to chain, pausing system")
-							l.systemService.Pause()
+							if err := l.systemService.Pause(); err != nil {
+								entry.
+									WithFields(log.Fields{"error": err}).
+									Warn("Unable to pause system")
+							}
 						} else {
 							entry.Warn("Unable to connect to chain")
 						}

--- a/chain_events/listener.go
+++ b/chain_events/listener.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	wallet_errors "github.com/flow-hydraulics/flow-wallet-api/errors"
 	"github.com/flow-hydraulics/flow-wallet-api/system"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/client"
@@ -116,13 +117,24 @@ func (l *Listener) Start() *Listener {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
+		entry := log.WithFields(log.Fields{
+			"package":  "chain_events",
+			"function": "Listener.Start.goroutine",
+		})
+
 		for {
 			select {
 			case <-l.done:
 				return
 			case <-l.ticker.C:
 				// Check for maintenance mode
-				if l.waitMaintenance() {
+				if halted, err := l.systemHalted(); err != nil {
+					entry.
+						WithFields(log.Fields{"error": err}).
+						Warn("Could not get system settings from DB")
+					continue
+				} else if halted {
+					entry.Debug("System halted")
 					continue
 				}
 
@@ -150,12 +162,23 @@ func (l *Listener) Start() *Listener {
 				})
 
 				if err != nil {
-					log.
+					if wallet_errors.IsChainConnectionError(err) {
+						// Unable to connect to chain, pause system.
+						if l.systemService != nil {
+							entry.Warn("Unable to connect to chain, pausing system")
+							l.systemService.Pause()
+						} else {
+							entry.Warn("Unable to connect to chain")
+						}
+						continue
+					}
+
+					entry.
 						WithFields(log.Fields{"error": err}).
 						Warn("Error while handling Flow events")
 
 					if strings.Contains(err.Error(), "key not found") {
-						log.Warn(`"key not found" error indicates data is not available at this height, please manually set correct starting height`)
+						entry.Warn(`"key not found" error indicates data is not available at this height, please manually set correct starting height`)
 					}
 				}
 			}
@@ -202,6 +225,13 @@ func (l *Listener) Stop() {
 	l.ticker = nil
 }
 
-func (l *Listener) waitMaintenance() bool {
-	return l.systemService != nil && l.systemService.IsMaintenanceMode()
+func (l *Listener) systemHalted() (bool, error) {
+	if l.systemService != nil {
+		s, err := l.systemService.GetSettings()
+		if err != nil {
+			return false, err
+		}
+		return s.IsMaintenanceMode() || s.IsPaused(), nil
+	}
+	return false, nil
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,17 +51,21 @@ services:
       - redis
 
   emulator:
-    image: gcr.io/flow-container-registry/emulator:v0.23.0
+    image: gcr.io/flow-container-registry/emulator:0.27.2
     restart: unless-stopped
-    command: emulator -v
+    command: emulator -v --persist
     ports:
       - "3569:3569"
+    volumes:
+      - emulator_persist:/flowdb
     env_file:
       - ./.env
     environment:
       - FLOW_SERVICEPRIVATEKEY=${FLOW_WALLET_ADMIN_PRIVATE_KEY}
       - FLOW_SERVICEKEYSIGALGO=ECDSA_P256
       - FLOW_SERVICEKEYHASHALGO=SHA3_256
+      - FLOW_DBPATH=/flowdb
 
 volumes:
   redis_data:
+  emulator_persist:

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,6 +1,8 @@
 // Package errors provides an API for errors across the application.
 package errors
 
+import "strings"
+
 type RequestError struct {
 	StatusCode int
 	Err        error
@@ -8,4 +10,9 @@ type RequestError struct {
 
 func (e *RequestError) Error() string {
 	return e.Err.Error()
+}
+
+func IsChainConnectionError(err error) bool {
+	// TODO: check this properly
+	return strings.Contains(err.Error(), "connection refused")
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -2,6 +2,8 @@
 package errors
 
 import (
+	"net"
+
 	"github.com/onflow/flow-go-sdk/client"
 	"google.golang.org/grpc/codes"
 )
@@ -16,12 +18,17 @@ func (e *RequestError) Error() string {
 }
 
 var accessAPIConnectionErrors = []codes.Code{
+	codes.DeadlineExceeded,
 	codes.ResourceExhausted,
 	codes.Internal,
 	codes.Unavailable,
 }
 
 func IsChainConnectionError(err error) bool {
+	if _, ok := err.(net.Error); ok {
+		return true
+	}
+
 	if err, ok := err.(client.RPCError); ok {
 		// Check for Flow Access API connection errors
 		for _, code := range accessAPIConnectionErrors {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -2,21 +2,69 @@ package errors
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/onflow/flow-go-sdk/client"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
-func TestIsChainConnectionError(t *testing.T) {
-	fc, err := client.New("non-existent-address", grpc.WithInsecure())
-	if err != nil {
-		t.Fatal(err)
-	}
+type testNetError struct{}
 
-	if _, err := fc.GetLatestBlock(context.Background(), true); err == nil {
-		t.Fatal("expected an error")
-	} else if !IsChainConnectionError(err) {
-		t.Fatal("expected error to be a connection error")
-	}
+func (e *testNetError) Error() string   { return "NetError" }
+func (e *testNetError) Timeout() bool   { return false }
+func (e *testNetError) Temporary() bool { return false }
+
+func TestIsChainConnectionError(t *testing.T) {
+	t.Run("error cases", func(t *testing.T) {
+		var netErr error = &testNetError{}
+
+		valid_errors := []error{
+			netErr,
+			client.RPCError{
+				GRPCErr: status.Error(codes.DeadlineExceeded, "DeadlineExceeded"),
+			},
+			client.RPCError{
+				GRPCErr: status.Error(codes.ResourceExhausted, "ResourceExhausted"),
+			},
+			client.RPCError{
+				GRPCErr: status.Error(codes.Internal, "Internal"),
+			},
+			client.RPCError{
+				GRPCErr: status.Error(codes.Unavailable, "Unavailable"),
+			},
+		}
+
+		invalid_errors := []error{
+			fmt.Errorf("not a connection error"),
+		}
+
+		for _, err := range valid_errors {
+			if !IsChainConnectionError(err) {
+				t.Fatalf("expected error to be a connection error, got \"%s\"", err)
+			}
+		}
+
+		for _, err := range invalid_errors {
+			if IsChainConnectionError(err) {
+				t.Fatalf("expected error not to be a connection error, got \"%s\"", err)
+			}
+		}
+	})
+
+	t.Run("non existent gateway", func(t *testing.T) {
+		fc, err := client.New("non-existent-address", grpc.WithInsecure())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := fc.GetLatestBlock(context.Background(), true); err == nil {
+			t.Fatal("expected an error")
+		} else if !IsChainConnectionError(err) {
+			t.Fatal("expected error to be a connection error")
+		}
+	})
+
 }

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1,0 +1,22 @@
+package errors
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onflow/flow-go-sdk/client"
+	"google.golang.org/grpc"
+)
+
+func TestIsChainConnectionError(t *testing.T) {
+	fc, err := client.New("non-existent-address", grpc.WithInsecure())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := fc.GetLatestBlock(context.Background(), true); err == nil {
+		t.Fatal("expected an error")
+	} else if !IsChainConnectionError(err) {
+		t.Fatal("expected error to be a connection error")
+	}
+}

--- a/jobs/jobs_test.go
+++ b/jobs/jobs_test.go
@@ -350,12 +350,16 @@ func TestJobErrorMessages(t *testing.T) {
 
 		// Explicitly retry to trigger n errors and a final successful execution, n = retryCount
 		for n := 0; n < retryCount+1; n++ {
-			wp.process(job)
+			if err := wp.process(job); err != nil {
+				t.Fatal(err)
+			}
 		}
 
 		// Send the notification
 		sendNotificationJob := <-wp.jobChan
-		wp.process(sendNotificationJob)
+		if err := wp.process(sendNotificationJob); err != nil {
+			t.Fatal(err)
+		}
 
 		// Check log entries
 		if len(hook.Entries) != retryCount {

--- a/jobs/jobs_test.go
+++ b/jobs/jobs_test.go
@@ -65,7 +65,9 @@ func TestScheduleSendNotification(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wp.process(job)
+	if err := wp.process(job); err != nil {
+		t.Fatal(err)
+	}
 
 	if len(wp.jobChan) == 0 {
 		t.Fatal("expected job channel to contain a job")
@@ -77,7 +79,9 @@ func TestScheduleSendNotification(t *testing.T) {
 		t.Fatalf("expected pool to have a send_job_status job")
 	}
 
-	wp.process(sendNotificationJob)
+	if err := wp.process(sendNotificationJob); err != nil {
+		t.Fatal(err)
+	}
 
 	if !sendNotificationCalled {
 		t.Fatalf("expected 'sendNotificationCalled' to equal true")
@@ -124,8 +128,13 @@ func TestExecuteSendNotification(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		wp.process(job)
-		wp.process(<-wp.jobChan)
+		if err := wp.process(job); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := wp.process(<-wp.jobChan); err != nil {
+			t.Fatal(err)
+		}
 
 		if webhookJob.Type != "TestJobType" {
 			t.Fatalf("expected webhook endpoint to have received a notification")
@@ -175,8 +184,12 @@ func TestExecuteSendNotification(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		wp.process(job)
-		wp.process(<-wp.jobChan)
+		if err := wp.process(job); err != nil {
+			t.Fatal(err)
+		}
+		if err := wp.process(<-wp.jobChan); err != nil {
+			t.Fatal(err)
+		}
 
 		if webhookJob.Type != "TestJobType" {
 			t.Fatalf("expected webhook endpoint to have received a notification")
@@ -219,7 +232,9 @@ func TestExecuteSendNotification(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		wp.process(job)
+		if err := wp.process(job); err != nil {
+			t.Fatal(err)
+		}
 
 		if len(wp.jobChan) != 0 {
 			t.Errorf("did not expect a job to be queued")
@@ -259,9 +274,15 @@ func TestExecuteSendNotification(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		wp.process(job)
+		if err := wp.process(job); err != nil {
+			t.Fatal()
+		}
+
 		sendNotificationJob := <-wp.jobChan
-		wp.process(sendNotificationJob)
+
+		if err := wp.process(sendNotificationJob); err != nil {
+			t.Fatal(err)
+		}
 
 		if len(hook.Entries) != 1 {
 			t.Errorf("expected there to be one warning, got %d", len(hook.Entries))

--- a/jobs/workerpool.go
+++ b/jobs/workerpool.go
@@ -232,11 +232,7 @@ func (wp *WorkerPool) accept(job *Job) bool {
 
 func (wp *WorkerPool) systemHalted() (bool, error) {
 	if wp.systemService != nil {
-		s, err := wp.systemService.GetSettings()
-		if err != nil {
-			return false, err
-		}
-		return s.IsMaintenanceMode() || s.IsPaused(), nil
+		return wp.systemService.IsHalted()
 	}
 	return false, nil
 }

--- a/jobs/workerpool.go
+++ b/jobs/workerpool.go
@@ -308,7 +308,11 @@ func (wp *WorkerPool) startWorkers() {
 						if wp.systemService != nil {
 							entry.Warn("Unable to connect to chain, pausing system")
 							// Unable to connect to chain, pause system.
-							wp.systemService.Pause()
+							if err := wp.systemService.Pause(); err != nil {
+								entry.
+									WithFields(log.Fields{"error": err}).
+									Warn("Unable to pause system")
+							}
 						} else {
 							entry.Warn("Unable to connect to chain")
 						}

--- a/main_test.go
+++ b/main_test.go
@@ -146,6 +146,9 @@ func getTestApp(t *testing.T, cfg *configs.Config, ignoreLeaks bool) TestApp {
 
 	fc, err := client.New(cfg.AccessAPIHost, grpc.WithInsecure())
 	fatal(t, err)
+
+	fatal(t, fc.Ping(context.Background()))
+
 	t.Cleanup(func() {
 		fc.Close()
 	})

--- a/migrations/internal/m20211130/migration.go
+++ b/migrations/internal/m20211130/migration.go
@@ -4,6 +4,7 @@ import (
 	"gorm.io/gorm"
 )
 
+// Note: there is an 'm' here, it is a typo but it should not be removed
 const ID = "m20211130"
 
 type Settings struct {

--- a/migrations/internal/m20211213/migration.go
+++ b/migrations/internal/m20211213/migration.go
@@ -1,0 +1,35 @@
+package m20211213
+
+import (
+	"database/sql"
+
+	"gorm.io/gorm"
+)
+
+const ID = "m20211213"
+
+type Settings struct {
+	gorm.Model
+	MaintenanceMode bool         `gorm:"column:maintenance_mode;default:false"`
+	PausedSince     sql.NullTime `gorm:"column:paused_since"`
+}
+
+func (Settings) TableName() string {
+	return "system_settings"
+}
+
+func Migrate(tx *gorm.DB) error {
+	if err := tx.AutoMigrate(&Settings{}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func Rollback(tx *gorm.DB) error {
+	if err := tx.Migrator().DropColumn(&Settings{}, "paused_since"); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/migrations/internal/m20211221_2/migration.go
+++ b/migrations/internal/m20211221_2/migration.go
@@ -1,3 +1,4 @@
+// m20211221_2 handles Settings.PausedSince migration
 package m20211221_2
 
 import (

--- a/migrations/internal/m20211221_2/migration.go
+++ b/migrations/internal/m20211221_2/migration.go
@@ -1,4 +1,4 @@
-package m20211213
+package m20211221_2
 
 import (
 	"database/sql"
@@ -6,7 +6,7 @@ import (
 	"gorm.io/gorm"
 )
 
-const ID = "m20211213"
+const ID = "20211221_2"
 
 type Settings struct {
 	gorm.Model

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -7,6 +7,7 @@ import (
 	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211118"
 	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211130"
 	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211202"
+	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211213"
 	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211220"
 	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211221_1"
 	"github.com/go-gormigrate/gormigrate/v2"
@@ -43,6 +44,11 @@ func List() []*gormigrate.Migration {
 			ID:       m20211202.ID,
 			Migrate:  m20211202.Migrate,
 			Rollback: m20211202.Rollback,
+		},
+		{
+			ID:       m20211213.ID,
+			Migrate:  m20211213.Migrate,
+			Rollback: m20211213.Rollback,
 		},
 		{
 			ID:       m20211220.ID,

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -7,9 +7,9 @@ import (
 	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211118"
 	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211130"
 	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211202"
-	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211213"
 	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211220"
 	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211221_1"
+	"github.com/flow-hydraulics/flow-wallet-api/migrations/internal/m20211221_2"
 	"github.com/go-gormigrate/gormigrate/v2"
 )
 
@@ -46,11 +46,6 @@ func List() []*gormigrate.Migration {
 			Rollback: m20211202.Rollback,
 		},
 		{
-			ID:       m20211213.ID,
-			Migrate:  m20211213.Migrate,
-			Rollback: m20211213.Rollback,
-		},
-		{
 			ID:       m20211220.ID,
 			Migrate:  m20211220.Migrate,
 			Rollback: m20211220.Rollback,
@@ -59,6 +54,11 @@ func List() []*gormigrate.Migration {
 			ID:       m20211221_1.ID,
 			Migrate:  m20211221_1.Migrate,
 			Rollback: m20211221_1.Rollback,
+		},
+		{
+			ID:       m20211221_2.ID,
+			Migrate:  m20211221_2.Migrate,
+			Rollback: m20211221_2.Rollback,
 		},
 	}
 	return ms

--- a/system/options.go
+++ b/system/options.go
@@ -1,0 +1,13 @@
+package system
+
+import (
+	"time"
+)
+
+type ServiceOption func(*Service)
+
+func WithPauseDuration(duration time.Duration) ServiceOption {
+	return func(svc *Service) {
+		svc.pauseDuration = duration
+	}
+}

--- a/system/service.go
+++ b/system/service.go
@@ -1,7 +1,9 @@
 package system
 
 import (
+	"database/sql"
 	"fmt"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -26,16 +28,12 @@ func (svc *Service) SaveSettings(settings *Settings) error {
 	return svc.store.SaveSettings(settings)
 }
 
-func (svc *Service) IsMaintenanceMode() bool {
+func (svc *Service) Pause() error {
+	log.Trace("Pause system")
 	settings, err := svc.GetSettings()
 	if err != nil {
-		log.
-			WithFields(log.Fields{
-				"error":    err,
-				"package":  "system",
-				"function": "IsMaintenanceMode",
-			}).
-			Warn("Error while getting system settings")
+		return err
 	}
-	return err == nil && settings.MaintenanceMode
+	settings.PausedSince = sql.NullTime{Time: time.Now(), Valid: true}
+	return svc.SaveSettings(settings)
 }

--- a/system/system.go
+++ b/system/system.go
@@ -1,14 +1,19 @@
 package system
 
 import (
+	"database/sql"
 	"fmt"
+	"time"
 
 	"gorm.io/gorm"
 )
 
+const pauseDuration = time.Minute
+
 type Settings struct {
 	gorm.Model
-	MaintenanceMode bool `gorm:"column:maintenance_mode;default:false"`
+	MaintenanceMode bool         `gorm:"column:maintenance_mode;default:false"`
+	PausedSince     sql.NullTime `gorm:"column:paused_since"`
 }
 
 func (s *Settings) String() string {
@@ -24,6 +29,14 @@ func (s *Settings) ToJSON() SettingsJSON {
 	return SettingsJSON{
 		MaintenanceMode: s.MaintenanceMode,
 	}
+}
+
+func (s *Settings) IsMaintenanceMode() bool {
+	return s.MaintenanceMode
+}
+
+func (s *Settings) IsPaused() bool {
+	return s.PausedSince.Valid && s.PausedSince.Time.After(time.Now().Add(-pauseDuration))
 }
 
 // Update fields according to JSON version

--- a/system/system.go
+++ b/system/system.go
@@ -8,8 +8,6 @@ import (
 	"gorm.io/gorm"
 )
 
-const pauseDuration = time.Minute
-
 type Settings struct {
 	gorm.Model
 	MaintenanceMode bool         `gorm:"column:maintenance_mode;default:false"`
@@ -35,7 +33,7 @@ func (s *Settings) IsMaintenanceMode() bool {
 	return s.MaintenanceMode
 }
 
-func (s *Settings) IsPaused() bool {
+func (s *Settings) IsPaused(pauseDuration time.Duration) bool {
 	return s.PausedSince.Valid && s.PausedSince.Time.After(time.Now().Add(-pauseDuration))
 }
 

--- a/tests/internal/test/flow.go
+++ b/tests/internal/test/flow.go
@@ -29,6 +29,10 @@ func NewFlowClient(t *testing.T, cfg *configs.Config) *client.Client {
 		t.Fatal(err)
 	}
 
+	if err := fc.Ping(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
 	close := func() {
 		err := fc.Close()
 		if err != nil {

--- a/tests/system_test.go
+++ b/tests/system_test.go
@@ -110,7 +110,7 @@ func TestIsPaused(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if settings.IsPaused() {
+	if settings.IsPaused(time.Minute) {
 		t.Error("expected system not to be paused")
 	}
 
@@ -125,7 +125,26 @@ func TestIsPaused(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !settings.IsPaused() {
+	if !settings.IsPaused(time.Minute) {
 		t.Error("expected system to be paused")
+	}
+}
+
+func TestPausing(t *testing.T) {
+	cfg := test.LoadConfig(t, testConfigPath)
+	svcs := test.GetServices(t, cfg)
+
+	sysService := svcs.GetSystem()
+
+	if halted, err := sysService.IsHalted(); err != nil || halted {
+		t.Error("expected system not to be halted")
+	}
+
+	if err := sysService.Pause(); err != nil {
+		t.Fatal(err)
+	}
+
+	if halted, err := sysService.IsHalted(); err != nil || !halted {
+		t.Error("expected system to be halted")
 	}
 }


### PR DESCRIPTION
If a job or event poll fails due to a flow AccessAPI connection error (GRPC error of `ResourceExhausted`, `Internal` or `Unavailable`), the system is paused.

- If the error happened during a job execution, the job will be returned to the pool.
- If the error happened during event polling, the system will retry the same blocks later. 

The system will be paused for 1 minute and no jobs or events will be handled during that time. After the grace period (1 minute), the system is resumed. 

In more detail, the system is paused by setting the `paused_since` timestamp on the system settings database table. 

TODO:
- ~Make sure we correctly detect chain offline situation~
- Add a test to for the grace period