### PR TITLE
Fixed token setup error handling

### DIFF
--- a/tests/tokens_service_test.go
+++ b/tests/tokens_service_test.go
@@ -1,0 +1,96 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+
+	"github.com/flow-hydraulics/flow-wallet-api/jobs"
+	"github.com/flow-hydraulics/flow-wallet-api/tests/internal/test"
+	"github.com/flow-hydraulics/flow-wallet-api/transactions"
+)
+
+func Test_TokensSetup(t *testing.T) {
+	cfg := test.LoadConfig(t, testConfigPath)
+	svc := test.GetServices(t, cfg).GetTokens()
+
+	type input struct {
+		sync      bool
+		tokenName string
+		address   string
+	}
+	type expect struct {
+		job *jobs.Job
+		tx  *transactions.Transaction
+		err bool
+	}
+	testCases := []struct {
+		name   string
+		input  input
+		expect expect
+	}{
+		{
+			name: "success",
+			input: input{
+				sync:      false,
+				tokenName: "flowToken",
+				address:   cfg.AdminAddress,
+			},
+			expect: expect{
+				job: &jobs.Job{
+					Type:                   transactions.TransactionJobType,
+					State:                  jobs.Init,
+					Error:                  "",
+					Result:                 "",
+					ExecCount:              int(1),
+					ShouldSendNotification: false,
+				},
+				tx: &transactions.Transaction{
+					TransactionType: transactions.FtSetup,
+					ProposerAddress: cfg.AdminAddress,
+				},
+				err: false,
+			},
+		},
+		{
+			name: "fail address not found",
+			input: input{
+				sync:      false,
+				tokenName: "flowToken",
+				address:   "0x0ae53cb6e3f42a79",
+			},
+			expect: expect{
+				job: nil,
+				tx:  nil,
+				err: true,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			job, tx, err := svc.Setup(context.Background(), tc.input.sync, tc.input.tokenName, tc.input.address)
+			jobOpts := []cmp.Option{
+				cmpopts.IgnoreFields(jobs.Job{}, "TransactionID", "ExecCount"),
+				cmpopts.IgnoreTypes(uuid.UUID{}, time.Time{}),
+			}
+			if diff := cmp.Diff(tc.expect.job, job, jobOpts...); diff != "" {
+				t.Fatalf("\n\n%s\n", diff)
+			}
+			txOpts := []cmp.Option{
+				cmpopts.IgnoreFields(transactions.Transaction{}, "TransactionId", "FlowTransaction"),
+				cmpopts.IgnoreTypes(time.Time{}),
+			}
+			if diff := cmp.Diff(tc.expect.tx, tx, txOpts...); diff != "" {
+				t.Fatalf("\n\n%s\n", diff)
+			}
+			if !tc.expect.err && err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/tests/tokens_service_test.go
+++ b/tests/tokens_service_test.go
@@ -18,6 +18,11 @@ func Test_TokensSetup(t *testing.T) {
 	cfg := test.LoadConfig(t, testConfigPath)
 	svc := test.GetServices(t, cfg).GetTokens()
 
+	_, testAccount, err := test.GetServices(t, cfg).GetAccounts().Create(context.Background(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	type input struct {
 		sync      bool
 		tokenName string
@@ -38,7 +43,7 @@ func Test_TokensSetup(t *testing.T) {
 			input: input{
 				sync:      false,
 				tokenName: "flowToken",
-				address:   cfg.AdminAddress,
+				address:   testAccount.Address,
 			},
 			expect: expect{
 				job: &jobs.Job{
@@ -47,11 +52,11 @@ func Test_TokensSetup(t *testing.T) {
 					Error:                  "",
 					Result:                 "",
 					ExecCount:              int(1),
-					ShouldSendNotification: false,
+					ShouldSendNotification: true,
 				},
 				tx: &transactions.Transaction{
 					TransactionType: transactions.FtSetup,
-					ProposerAddress: cfg.AdminAddress,
+					ProposerAddress: testAccount.Address,
 				},
 				error: false,
 			},

--- a/tests/tokens_service_test.go
+++ b/tests/tokens_service_test.go
@@ -24,9 +24,9 @@ func Test_TokensSetup(t *testing.T) {
 		address   string
 	}
 	type expect struct {
-		job *jobs.Job
-		tx  *transactions.Transaction
-		err bool
+		job   *jobs.Job
+		tx    *transactions.Transaction
+		error bool
 	}
 	testCases := []struct {
 		name   string
@@ -53,7 +53,7 @@ func Test_TokensSetup(t *testing.T) {
 					TransactionType: transactions.FtSetup,
 					ProposerAddress: cfg.AdminAddress,
 				},
-				err: false,
+				error: false,
 			},
 		},
 		{
@@ -64,9 +64,9 @@ func Test_TokensSetup(t *testing.T) {
 				address:   "0x0ae53cb6e3f42a79",
 			},
 			expect: expect{
-				job: nil,
-				tx:  nil,
-				err: true,
+				job:   nil,
+				tx:    nil,
+				error: true,
 			},
 		},
 	}
@@ -88,8 +88,8 @@ func Test_TokensSetup(t *testing.T) {
 			if diff := cmp.Diff(tc.expect.tx, tx, txOpts...); diff != "" {
 				t.Fatalf("\n\n%s\n", diff)
 			}
-			if !tc.expect.err && err != nil {
-				t.Fatal(err)
+			if (err != nil) != tc.expect.error {
+				t.Fatal("error mismatch")
 			}
 		})
 	}

--- a/tests/tokens_service_test.go
+++ b/tests/tokens_service_test.go
@@ -29,9 +29,9 @@ func Test_TokensSetup(t *testing.T) {
 		address   string
 	}
 	type expect struct {
-		job          *jobs.Job
-		tx           *transactions.Transaction
-		errorMessage string
+		job    *jobs.Job
+		tx     *transactions.Transaction
+		errMsg string
 	}
 	testCases := []struct {
 		name   string
@@ -58,7 +58,7 @@ func Test_TokensSetup(t *testing.T) {
 					TransactionType: transactions.FtSetup,
 					ProposerAddress: testAccount.Address,
 				},
-				errorMessage: "",
+				errMsg: "",
 			},
 		},
 		{
@@ -69,9 +69,9 @@ func Test_TokensSetup(t *testing.T) {
 				address:   "0x0ae53cb6e3f42a79",
 			},
 			expect: expect{
-				job:          nil,
-				tx:           nil,
-				errorMessage: "error while getting new transaction: error while building transaction: error while getting user authorizer: WHERE conditions required",
+				job:    nil,
+				tx:     nil,
+				errMsg: "record not found",
 			},
 		},
 	}
@@ -97,11 +97,11 @@ func Test_TokensSetup(t *testing.T) {
 			if diff := cmp.Diff(tc.expect.tx, tx, txOpts...); diff != "" {
 				t.Fatalf("\n\n%s\n", diff)
 			}
-			var errorMessage string
+			var errMsg string
 			if err != nil {
-				errorMessage = err.Error()
+				errMsg = err.Error()
 			}
-			if diff := cmp.Diff(tc.expect.errorMessage, errorMessage); diff != "" {
+			if diff := cmp.Diff(tc.expect.errMsg, errMsg); diff != "" {
 				t.Fatalf("\n\n%s\n", diff)
 			}
 		})

--- a/tokens/service.go
+++ b/tokens/service.go
@@ -82,7 +82,7 @@ func (s *Service) Setup(ctx context.Context, sync bool, tokenName, address strin
 	}
 
 	job, tx, err := s.transactions.Create(ctx, sync, address, token.Setup, nil, txType)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "vault exists") {
 		return nil, nil, err
 	}
 

--- a/tokens/service.go
+++ b/tokens/service.go
@@ -67,6 +67,12 @@ func (s *Service) Setup(ctx context.Context, sync bool, tokenName, address strin
 		return nil, nil, err
 	}
 
+	// Check if the account with given address exists
+	_, err = s.accounts.Details(address)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	token, err := s.templates.GetTokenByName(tokenName)
 	if err != nil {
 		return nil, nil, err
@@ -82,9 +88,6 @@ func (s *Service) Setup(ctx context.Context, sync bool, tokenName, address strin
 	}
 
 	job, tx, err := s.transactions.Create(ctx, sync, address, token.Setup, nil, txType)
-	if err != nil && !strings.Contains(err.Error(), "vault exists") {
-		return nil, nil, err
-	}
 
 	if err == nil || strings.Contains(err.Error(), "vault exists") {
 		// Handle adding token to account in database

--- a/tokens/service.go
+++ b/tokens/service.go
@@ -82,6 +82,9 @@ func (s *Service) Setup(ctx context.Context, sync bool, tokenName, address strin
 	}
 
 	job, tx, err := s.transactions.Create(ctx, sync, address, token.Setup, nil, txType)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	if err == nil || strings.Contains(err.Error(), "vault exists") {
 		// Handle adding token to account in database


### PR DESCRIPTION
Fixed error handling of `Setup` function of token service which was causing panic when specified account address was not found in db.  

```shell
wallet-api-1  | time="2021-12-26T08:49:12Z" level=warning msg="Error while handling request" error="error while getting new transaction: error while building transaction: error while getting user authorizer: client: rpc error: code = NotFound desc = could not find account with address 01cf0e2f2f715450"
wallet-api-1  | time="2021-12-26T08:49:12Z" level=info msg="HTTP request" duration=17.016 method=POST path="/v1/accounts/0x01cf0e2f2f715450/non-fungible-tokens/TestToken?sync=" remote="172.20.0.1:58168" size=203 status=400 user-agent=axios/0.24.0
wallet-api-1  | panic: runtime error: invalid memory address or nil pointer dereference
wallet-api-1  | [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xb819e3]
wallet-api-1  |
wallet-api-1  | goroutine 717 [running]:
wallet-api-1  | github.com/flow-hydraulics/flow-wallet-api/jobs.(*Job).Wait(0x0, 0x0)
wallet-api-1  |     /build/jobs/jobs.go:86 +0x43
wallet-api-1  | github.com/flow-hydraulics/flow-wallet-api/tokens.(*Service).Setup.func1()
wallet-api-1  |     /build/tokens/service.go:78 +0x6c
wallet-api-1  | created by github.com/flow-hydraulics/flow-wallet-api/tokens.(*Service).Setup
wallet-api-1  |     /build/tokens/service.go:76 +0x2d9
```
