### PR TITLE
Add AcceptJob

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,11 +38,6 @@ jobs:
           sleep 1
           cd flow && flow project deploy --network=emulator --update=true
 
-      - name: Run postgres in background
-        run: |
-          cp .env.test .env
-          docker-compose -f docker-compose.dev.yml up -d db
-
       - name: Cache Go modules
         uses: actions/cache@v1
         with:
@@ -53,8 +48,6 @@ jobs:
 
       - name: Run tests
         env:
-          FLOW_WALLET_DATABASE_TYPE: "psql"
-          FLOW_WALLET_DATABASE_DSN: "postgresql://wallet:wallet@localhost:5432/wallet"
           FLOW_WALLET_ADMIN_ADDRESS: "0xf8d6e0586b0a20c7"
           FLOW_WALLET_ADMIN_PRIVATE_KEY: "91a22fbd87392b019fbe332c32695c14cf2ba5b6521476a8540228bdf1987068"
           FLOW_WALLET_ADMIN_PROPOSAL_KEY_COUNT: "100"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,10 @@ jobs:
           sleep 1
           cd flow && flow project deploy --network=emulator --update=true
 
+      - name: Run postgres in background
+        run: |
+          cp .env.test .env
+          docker-compose -f docker-compose.dev.yml up -d db
 
       - name: Cache Go modules
         uses: actions/cache@v1
@@ -49,6 +53,8 @@ jobs:
 
       - name: Run tests
         env:
+          FLOW_WALLET_DATABASE_TYPE: "psql"
+          FLOW_WALLET_DATABASE_DSN: "postgresql://wallet:wallet@localhost:5432/wallet"
           FLOW_WALLET_ADMIN_ADDRESS: "0xf8d6e0586b0a20c7"
           FLOW_WALLET_ADMIN_PRIVATE_KEY: "91a22fbd87392b019fbe332c32695c14cf2ba5b6521476a8540228bdf1987068"
           FLOW_WALLET_ADMIN_PROPOSAL_KEY_COUNT: "100"

--- a/jobs/jobs_test.go
+++ b/jobs/jobs_test.go
@@ -23,7 +23,7 @@ func (*dummyStore) Jobs(datastore.ListOptions) ([]Job, error) { return nil, nil 
 func (*dummyStore) Job(id uuid.UUID) (Job, error)             { return Job{}, nil }
 func (*dummyStore) InsertJob(*Job) error                      { return nil }
 func (*dummyStore) UpdateJob(*Job) error                      { return nil }
-func (*dummyStore) IncreaseExecCount(j *Job) error {
+func (*dummyStore) AcceptJob(j *Job, acceptedGracePeriod time.Duration) error {
 	j.ExecCount = j.ExecCount + 1
 	return nil
 }

--- a/jobs/store.go
+++ b/jobs/store.go
@@ -13,7 +13,7 @@ type Store interface {
 	Job(id uuid.UUID) (Job, error)
 	InsertJob(*Job) error
 	UpdateJob(*Job) error
-	IncreaseExecCount(j *Job) error
+	AcceptJob(j *Job, acceptedGracePeriod time.Duration) error
 	SchedulableJobs(acceptedGracePeriod, reSchedulableGracePeriod time.Duration, o datastore.ListOptions) ([]Job, error)
 	Status() ([]StatusQuery, error)
 }

--- a/jobs/store_gorm.go
+++ b/jobs/store_gorm.go
@@ -1,11 +1,13 @@
 package jobs
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/flow-hydraulics/flow-wallet-api/datastore"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type GormStore struct {
@@ -38,10 +40,28 @@ func (s *GormStore) UpdateJob(j *Job) error {
 	return s.db.Save(j).Error
 }
 
-func (s *GormStore) IncreaseExecCount(j *Job) error {
-	return s.db.Model(j).
-		Where("id = ? AND exec_count = ? AND updated_at = ?", j.ID, j.ExecCount, j.UpdatedAt).
-		Update("exec_count", j.ExecCount+1).Error
+func (s *GormStore) AcceptJob(j *Job, acceptedGracePeriod time.Duration) error {
+	tAccepted := time.Now().Add(-1 * acceptedGracePeriod)
+	if j.State == Accepted && j.UpdatedAt.After(tAccepted) {
+		return fmt.Errorf("error job is already accepted")
+	}
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		var job Job
+		err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&job, "id = ?", j.ID).Error
+		if err != nil {
+			return err
+		}
+		if job.State == Accepted && job.UpdatedAt.After(tAccepted) {
+			return fmt.Errorf("error job is already accepted")
+		}
+		j.State = Accepted
+		j.ExecCount = job.ExecCount + 1
+		err = tx.Save(j).Error
+		if err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 func (s *GormStore) SchedulableJobs(acceptedGracePeriod, reSchedulableGracePeriod time.Duration, o datastore.ListOptions) (jj []Job, err error) {

--- a/jobs/store_gorm.go
+++ b/jobs/store_gorm.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/flow-hydraulics/flow-wallet-api/datastore"
+	ds_gorm "github.com/flow-hydraulics/flow-wallet-api/datastore/gorm"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -55,7 +56,7 @@ func (s *GormStore) AcceptJob(j *Job, acceptedGracePeriod time.Duration) error {
 	if !isAcceptable(j, acceptedGracePeriod) {
 		return fmt.Errorf("error job is not acceptable")
 	}
-	return s.db.Transaction(func(tx *gorm.DB) error {
+	return ds_gorm.Transaction(s.db, func(tx *gorm.DB) error {
 		var job Job
 		err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&job, "id = ?", j.ID).Error
 		if err != nil {

--- a/jobs/store_gorm.go
+++ b/jobs/store_gorm.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/flow-hydraulics/flow-wallet-api/datastore"
-	ds_gorm "github.com/flow-hydraulics/flow-wallet-api/datastore/gorm"
+	"github.com/flow-hydraulics/flow-wallet-api/datastore/lib"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -56,7 +56,7 @@ func (s *GormStore) AcceptJob(j *Job, acceptedGracePeriod time.Duration) error {
 	if !isAcceptable(j, acceptedGracePeriod) {
 		return fmt.Errorf("error job is not acceptable")
 	}
-	return ds_gorm.Transaction(s.db, func(tx *gorm.DB) error {
+	return lib.GormTransaction(s.db, func(tx *gorm.DB) error {
 		var job Job
 		err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&job, "id = ?", j.ID).Error
 		if err != nil {

--- a/jobs/workerpool.go
+++ b/jobs/workerpool.go
@@ -237,10 +237,10 @@ func (wp *WorkerPoolImpl) accept(job *Job) bool {
 		"function": "WorkerPool.accept",
 	}))
 
-	if err := wp.store.IncreaseExecCount(job); err != nil {
+	if err := wp.store.AcceptJob(job, wp.acceptedGracePeriod); err != nil {
 		entry.
 			WithFields(log.Fields{"error": err}).
-			Warn("Failed to increase job exec_count")
+			Warn("Failed to accept job")
 		return false
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -1160,7 +1160,7 @@ func TestTokenHandlers(t *testing.T) {
 			method:      http.MethodGet,
 			contentType: "application/json",
 			url:         fmt.Sprintf("/%s/fungible-tokens", testAccounts[1].Address),
-			expected:    `(?m)^\[{"name":"FUSD".*"name":"FlowToken".*}\]$`,
+			expected:    `(?m)^\[({"name":"FUSD".*"name":"FlowToken".*}|{"name":"FlowToken".*"name":"FUSD".*})\]$`,
 			status:      http.StatusOK,
 		},
 	}

--- a/migrations/internal/m20211220/migration.go
+++ b/migrations/internal/m20211220/migration.go
@@ -4,7 +4,6 @@ package m20211220
 import (
 	"time"
 
-	"github.com/flow-hydraulics/flow-wallet-api/jobs"
 	"github.com/google/uuid"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
@@ -16,7 +15,7 @@ const ID = "20211220"
 type Job struct {
 	ID                     uuid.UUID      `gorm:"column:id;primary_key;type:uuid;"`
 	Type                   string         `gorm:"column:type"`
-	State                  jobs.State     `gorm:"column:state;default:INIT"`
+	State                  string         `gorm:"column:state;default:INIT"`
 	Error                  string         `gorm:"column:error"`
 	Result                 string         `gorm:"column:result"`
 	TransactionID          string         `gorm:"column:transaction_id"`

--- a/migrations/internal/m20211220/migration.go
+++ b/migrations/internal/m20211220/migration.go
@@ -4,6 +4,7 @@ package m20211220
 import (
 	"time"
 
+	"github.com/flow-hydraulics/flow-wallet-api/jobs"
 	"github.com/google/uuid"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
@@ -15,7 +16,7 @@ const ID = "20211220"
 type Job struct {
 	ID                     uuid.UUID      `gorm:"column:id;primary_key;type:uuid;"`
 	Type                   string         `gorm:"column:type"`
-	State                  string         `gorm:"column:state;default:INIT"`
+	State                  jobs.State     `gorm:"column:state;default:INIT"`
 	Error                  string         `gorm:"column:error"`
 	Result                 string         `gorm:"column:result"`
 	TransactionID          string         `gorm:"column:transaction_id"`

--- a/tests/test/service.go
+++ b/tests/test/service.go
@@ -94,8 +94,8 @@ func GetServices(t *testing.T, cfg *configs.Config) Services {
 		cfg.WorkerCount,
 		jobs.WithMaxJobErrorCount(0),
 		jobs.WithDbJobPollInterval(time.Second),
-		jobs.WithAcceptedGracePeriod(0),
-		jobs.WithReSchedulableGracePeriod(0),
+		jobs.WithAcceptedGracePeriod(1000),
+		jobs.WithReSchedulableGracePeriod(1000),
 	)
 
 	km := basic.NewKeyManager(cfg, keys.NewGormStore(db), fc)


### PR DESCRIPTION
Related to https://github.com/flow-hydraulics/flow-wallet-api/issues/241 https://github.com/flow-hydraulics/flow-wallet-api/issues/94

Added `AcceptJob` to job store which updates job as `ACCEPTED` in transaction.
This feature will prevent jobs from being executed multiple times concurrently.