### PR TITLE
Fix enqueue jobs

### DIFF
--- a/jobs/workerpool.go
+++ b/jobs/workerpool.go
@@ -288,8 +288,8 @@ func (wp *WorkerPoolImpl) startDBJobScheduler() {
 				continue
 			}
 
-			for _, j := range jobs {
-				wp.tryEnqueue(&j, true)
+			for i := range jobs {
+				wp.tryEnqueue(&jobs[i], true)
 			}
 
 			elapsed := time.Since(begin)


### PR DESCRIPTION
Fixed: https://github.com/flow-hydraulics/flow-wallet-api/issues/260

Fixed issue with rescheduling jobs. The cause of the problem was the use of pointer when sending jobs to channel.
The previous implementation was sending pointer of `j` to channel and it resulted in that queued jobs reference same address.

So I fixed to send each job's pointer to channel.

### Before
```go
for _, j := range jobs {
  wp.tryEnqueue(&j, true)
}
```

### After
```go
for i := range jobs {
  wp.tryEnqueue(&jobs[i], true)
}
```