### PR TITLE
Add "sync key count for existing account" endpoint

### DIFF
--- a/accounts/jobs.go
+++ b/accounts/jobs.go
@@ -2,8 +2,12 @@ package accounts
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	"github.com/flow-hydraulics/flow-wallet-api/jobs"
+	"github.com/onflow/flow-go-sdk"
+	log "github.com/sirupsen/logrus"
 )
 
 const AccountCreateJobType = "account_create"
@@ -22,6 +26,41 @@ func (s *ServiceImpl) executeAccountCreateJob(ctx context.Context, j *jobs.Job) 
 
 	j.TransactionID = txID
 	j.Result = a.Address
+
+	return nil
+}
+
+const SyncAccountKeyCountJobType = "sync_account_key_count"
+
+type syncAccountKeyCountJobAttributes struct {
+	Address flow.Address `json:"address"`
+	NumKeys int          `json:"numkeys"`
+}
+
+func (s *ServiceImpl) executeSyncAccountKeyCountJob(ctx context.Context, j *jobs.Job) error {
+	entry := log.WithFields(log.Fields{"job": j, "function": "executeSyncAccountKeyCountJob"})
+	if j.Type != SyncAccountKeyCountJobType {
+		return jobs.ErrInvalidJobType
+	}
+
+	j.ShouldSendNotification = true
+
+	var attrs syncAccountKeyCountJobAttributes
+	err := json.Unmarshal(j.Attributes, &attrs)
+	if err != nil {
+		return err
+	}
+
+	entry.WithFields(log.Fields{"attrs": j.Attributes}).Trace("Unmarshaled attributes")
+
+	numKeys, txID, err := s.syncAccountKeyCount(ctx, attrs.Address, attrs.NumKeys)
+	entry.WithFields(log.Fields{"numKeys": numKeys, "txId": txID, "err": err}).Trace("s.syncAccountKeyCount complete")
+	if err != nil {
+		return err
+	}
+
+	j.TransactionID = txID
+	j.Result = fmt.Sprintf("%s:%d", attrs.Address, numKeys)
 
 	return nil
 }

--- a/accounts/store.go
+++ b/accounts/store.go
@@ -15,6 +15,9 @@ type Store interface {
 	// Insert a new account.
 	InsertAccount(a *Account) error
 
+	// Update an existing account.
+	SaveAccount(a *Account) error
+
 	// Permanently delete an account, despite of `DeletedAt` field.
 	HardDeleteAccount(a *Account) error
 }

--- a/accounts/store_gorm.go
+++ b/accounts/store_gorm.go
@@ -31,6 +31,10 @@ func (s *GormStore) InsertAccount(a *Account) error {
 	return s.db.Create(a).Error
 }
 
+func (s *GormStore) SaveAccount(a *Account) error {
+	return s.db.Save(&a).Error
+}
+
 func (s *GormStore) HardDeleteAccount(a *Account) error {
 	return s.db.Unscoped().Delete(a).Error
 }

--- a/api-test-scripts/system.http
+++ b/api-test-scripts/system.http
@@ -9,3 +9,13 @@ idempotency-key: {{$guid}}
 {
   "maintenanceMode":false
 }
+
+
+### Sync account key counts
+POST http://localhost:3000/v1/system/sync-account-key-count HTTP/1.1
+content-type: application/json
+idempotency-key: {{$guid}}
+
+{
+  "address": "0x01"
+}

--- a/handlers/accounts.go
+++ b/handlers/accounts.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/flow-hydraulics/flow-wallet-api/accounts"
+	"github.com/onflow/flow-go-sdk"
 )
 
 // Accounts is a HTTP server for account management.
@@ -11,6 +12,11 @@ import (
 // It uses an account service to interface with data.
 type Accounts struct {
 	service accounts.Service
+}
+
+// SyncKeyCountRequest represents a JSON payload for a HTTP request
+type SyncKeyCountRequest struct {
+	Address flow.Address `json:"address"`
 }
 
 // NewAccounts initiates a new accounts server.
@@ -32,6 +38,10 @@ func (s *Accounts) AddNonCustodialAccount() http.Handler {
 
 func (s *Accounts) DeleteNonCustodialAccount() http.Handler {
 	return http.HandlerFunc(s.DeleteNonCustodialAccountFunc)
+}
+
+func (s *Accounts) SyncAccountKeyCount() http.Handler {
+	return http.HandlerFunc(s.SyncAccountKeyCountFunc)
 }
 
 func (s *Accounts) Details() http.Handler {

--- a/handlers/accounts_func.go
+++ b/handlers/accounts_func.go
@@ -111,3 +111,27 @@ func (s *Accounts) DeleteNonCustodialAccountFunc(rw http.ResponseWriter, r *http
 
 	rw.WriteHeader(http.StatusOK)
 }
+
+func (s *Accounts) SyncAccountKeyCountFunc(rw http.ResponseWriter, r *http.Request) {
+	// Check body is not empty
+	if err := checkNonEmptyBody(r); err != nil {
+		handleError(rw, r, err)
+		return
+	}
+
+	var req SyncKeyCountRequest
+	// Try to decode the request body.
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		err = &errors.RequestError{StatusCode: http.StatusBadRequest, Err: fmt.Errorf("invalid body")}
+		handleError(rw, r, err)
+		return
+	}
+
+	job, err := s.service.SyncAccountKeyCount(r.Context(), req.Address)
+	if err != nil {
+		handleError(rw, r, err)
+		return
+	}
+
+	handleJsonResponse(rw, http.StatusOK, job)
+}

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func runServer(cfg *configs.Config) {
 	templateService := templates.NewService(cfg, templates.NewGormStore(db))
 	jobsService := jobs.NewService(jobs.NewGormStore(db))
 	transactionService := transactions.NewService(cfg, transactions.NewGormStore(db), km, fc, wp, transactions.WithTxRatelimiter(txRatelimiter))
-	accountService := accounts.NewService(cfg, accounts.NewGormStore(db), km, fc, wp, accounts.WithTxRatelimiter(txRatelimiter))
+	accountService := accounts.NewService(cfg, accounts.NewGormStore(db), km, fc, wp, transactionService, accounts.WithTxRatelimiter(txRatelimiter))
 	tokenService := tokens.NewService(cfg, tokens.NewGormStore(db), km, fc, wp, transactionService, templateService, accountService)
 
 	// Register a handler for account added events
@@ -159,6 +159,8 @@ func runServer(cfg *configs.Config) {
 	// System
 	rv.Handle("/system/settings", systemHandler.GetSettings()).Methods(http.MethodGet)
 	rv.Handle("/system/settings", systemHandler.SetSettings()).Methods(http.MethodPost)
+
+	rv.Handle("/system/sync-account-key-count", accountHandler.SyncAccountKeyCount()).Methods(http.MethodPost)
 
 	// Jobs
 	rv.Handle("/jobs", jobsHandler.List()).Methods(http.MethodGet)            // list

--- a/openapi.yml
+++ b/openapi.yml
@@ -123,6 +123,33 @@ paths:
         description: Post only fields you want to be changed.
       parameters:
         - $ref: '#/components/parameters/idempotencyKey'
+  /system/sync-account-key-count:
+    post:
+      summary: Sync key count for existing accounts
+      tags:
+        - System
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/job'
+      operationId: post-system-sync-account-key-count
+      parameters:
+        - $ref: '#/components/parameters/idempotencyKey'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                address:
+                  type: string
+            examples:
+              example-1:
+                value:
+                  address: '0xf669cb8d41ce0c74'
   /health/ready:
     get:
       summary: Healthcheck ready
@@ -1030,11 +1057,11 @@ components:
         payloadSignatures:
           type: array
           items:
-            $ref: '#components/schemas/transactionSignature'
+            $ref: '#/components/schemas/transactionSignature'
         envelopeSignatures:
           type: array
           items:
-            $ref: '#components/schemas/transactionSignature'
+            $ref: '#/components/schemas/transactionSignature'
     transactionSignature:
       type: object
       properties:

--- a/templates/template_strings/transactions.go
+++ b/templates/template_strings/transactions.go
@@ -75,7 +75,7 @@ transaction {
 `
 
 const AddProposalKeyTransaction = `
-transaction(adminKeyIndex: Int, numProposalKeys: UInt16) {  
+transaction(adminKeyIndex: Int, numProposalKeys: UInt16) {
   prepare(account: AuthAccount) {
     let key = account.keys.get(keyIndex: adminKeyIndex)!
     var count: UInt16 = 0
@@ -86,6 +86,26 @@ transaction(adminKeyIndex: Int, numProposalKeys: UInt16) {
             weight: 0.0
         )
         count = count + 1
+    }
+  }
+}
+`
+
+// TODO: sigAlgo & hashAlgo as params, add pre-&post-conditions
+const AddAccountKeysTransaction = `
+transaction(publicKeys: [String]) {
+  prepare(signer: AuthAccount) {
+    for pbk in publicKeys {
+      let key = PublicKey(
+        publicKey: pbk.decodeHex(),
+        signatureAlgorithm: SignatureAlgorithm.ECDSA_P256
+      )
+
+      signer.keys.add(
+        publicKey: key,
+        hashAlgorithm: HashAlgorithm.SHA3_256,
+        weight: 1000.0
+      )
     }
   }
 }

--- a/tests/test/service.go
+++ b/tests/test/service.go
@@ -108,7 +108,7 @@ func GetServices(t *testing.T, cfg *configs.Config) Services {
 
 	templateService := templates.NewService(cfg, templates.NewGormStore(db))
 	transactionService := transactions.NewService(cfg, transactions.NewGormStore(db), km, fc, wp)
-	accountService := accounts.NewService(cfg, accounts.NewGormStore(db), km, fc, wp)
+	accountService := accounts.NewService(cfg, accounts.NewGormStore(db), km, fc, wp, transactionService)
 	jobService := jobs.NewService(jobs.NewGormStore(db))
 	tokenService := tokens.NewService(cfg, tokens.NewGormStore(db), km, fc, wp, transactionService, templateService, accountService)
 


### PR DESCRIPTION
This adds a new endpoint `POST /v1/system/sync-account-key-count`, that will sync the key count for one given address i.e. add copies of the account key if needed (e.g. when `DefaultAccountKeyCount` has been changed).