### PR TITLE
Use latest finalized block for reference

### DIFF
--- a/flow_helpers/flow_helpers.go
+++ b/flow_helpers/flow_helpers.go
@@ -32,7 +32,7 @@ const hexPrefix = "0x"
 
 // LatestBlockId retuns the flow.Identifier for the latest block in the chain.
 func LatestBlockId(ctx context.Context, flowClient FlowClient) (*flow.Identifier, error) {
-	block, err := flowClient.GetLatestBlockHeader(ctx, true)
+	block, err := flowClient.GetLatestBlockHeader(ctx, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When there is gap between sealed block height and finalized block height, the tx which refers to sealed block height will immediately expire and fail. I observed that some of the txs were failing with error below. 

```
client: rpc error: code = InvalidArgument desc = invalid transaction: transaction is expired: ref_height=60118263 final_height=60119981
```

To avoid this error, it is safer to always refer to finalized block height for new transactions according to https://github.com/onflow/flow-go/pull/1607.


FYI: tx expires if its reference block height is 600 blocks behind the latest finalized block height.
> A transaction expires after 600 blocks are committed on top of the reference block, which takes about 10 minutes at average Mainnet block rates

ref: https://docs.onflow.org/flow-go-sdk/#transactions